### PR TITLE
Added notes about format type (i.e. csv) supported by kafka topic and…

### DIFF
--- a/modules/data-loading/pages/kafka-loader-user-guide.adoc
+++ b/modules/data-loading/pages/kafka-loader-user-guide.adoc
@@ -6,7 +6,8 @@ Kafka is a popular pub-sub system in enterprise IT, offering a distributed and f
 
 [NOTE]
 ====
-Currently, the format of messages consumed from Kafka topic is csv. In case messages are failed to be parsed and injected the Kafka Loader will directly skip them. 
+Currently, the format of messages consumed from Kafka topic is CSV. 
+If the Kafka loader fails to parse messages due to formatting issues, the Kafka Loader will skip the messages the fail to be parsed. 
 ====
 
 The Kafka Loader consumes data in a Kafka cluster and loads data into the TigerGraph system.
@@ -331,5 +332,3 @@ CREATE LOADING JOB load_person FOR GRAPH test_graph {
 # load the data
 RUN LOADING JOB load_person
 ----
-
-##

--- a/modules/data-loading/pages/kafka-loader-user-guide.adoc
+++ b/modules/data-loading/pages/kafka-loader-user-guide.adoc
@@ -6,7 +6,7 @@ Kafka is a popular pub-sub system in enterprise IT, offering a distributed and f
 
 [NOTE]
 ====
-Currently, the format of messages consumed from Kafka topic is csv. In case messages are failed to be parsed and injested the Kafka Loader will directelly skip them. 
+Currently, the format of messages consumed from Kafka topic is csv. In case messages are failed to be parsed and injected the Kafka Loader will directly skip them. 
 ====
 
 The Kafka Loader consumes data in a Kafka cluster and loads data into the TigerGraph system.

--- a/modules/data-loading/pages/kafka-loader-user-guide.adoc
+++ b/modules/data-loading/pages/kafka-loader-user-guide.adoc
@@ -4,6 +4,11 @@
 
 Kafka is a popular pub-sub system in enterprise IT, offering a distributed and fault-tolerant real-time data pipeline. TigerGraph's Kafka Loader feature lets you easily integrate with a Kafka cluster and speed up your real-time data ingestion. It is easily extensible using the many plugins available in the Kafka ecosystem.
 
+[NOTE]
+====
+Currently, the format of messages consumed from Kafka topic is csv. In case messages are failed to be parsed and injested the Kafka Loader will directelly skip them. 
+====
+
 The Kafka Loader consumes data in a Kafka cluster and loads data into the TigerGraph system.
 
 == Architecture 
@@ -326,5 +331,7 @@ CREATE LOADING JOB load_person FOR GRAPH test_graph {
 # load the data
 RUN LOADING JOB load_person
 ----
+
+In case 
 
 ##

--- a/modules/data-loading/pages/kafka-loader-user-guide.adoc
+++ b/modules/data-loading/pages/kafka-loader-user-guide.adoc
@@ -332,6 +332,4 @@ CREATE LOADING JOB load_person FOR GRAPH test_graph {
 RUN LOADING JOB load_person
 ----
 
-In case 
-
 ##


### PR DESCRIPTION
Adding notes about what is the supported file format for kafka loader and the behaviour for wrong file format. 

The current supported file format for kafka loader is csv. 