### PR TITLE
added comparison of editions

### DIFF
--- a/modules/intro/pages/comparison-of-editions.adoc
+++ b/modules/intro/pages/comparison-of-editions.adoc
@@ -5,48 +5,55 @@ This document compares what is included in the Enterprise Edition vs. TigerGraph
 To see what has been added or changed in different releases (versions) of TigerGraph, see xref:release-notes:change-log.adoc[Change Log].
 
 == Overview
-[width="100%",cols="<34%,<33%,<33%",options="header",]
+[width="100%",cols="<34%a,<33%a,<33%a",options="header"]
 |===
-| |TigerGraph Cloud |Enterprise Edition
-|*Licensing* |Pay as you go by the minute; Annual contracts available |A
-free license is available with up to 50 GB storage after compression -
-https://info.tigergraph.com/pricing[contact us] for a paid version
-without storage limitations
+| |https://info.tigergraph.com/enterprise-free[Enterprise Edition] |https://www.tigergraph.com/cloud[TigerGraph Cloud]
 
-|*Includes* a|
-The power of TigerGraph, as a service
+|*Licensing* |
+* A free license is available with up to 50 GB storage after compression
+* https://info.tigergraph.com/pricing[Contact us] for a paid version
+without storage limitations |
+The following options are available:
 
-+ Instant Deployment
+* Free tier solutions
+* Paid tier solutions
+** Pay as you go by the minute
+** Annual contracts
+** Public cloud marketplaces
 
-+ Automatic backups
+|*Includes*
+| All TigerGraph database and enterprise features, including
 
-+ Scaling out & Replication
+* xref:continuous-availability-overview.adoc[Distributed graph]
+* xref:multigraph-overview.adoc[MultiGraph]
+* xref:crr:cross-region-replication.adoc[Cross region replication]
+* xref:cluster-resizing:[Cluster resizing]
+* xref:backup-and-restore:index.adoc[Backup and restore]
+* xref:security:encrypting-connections.adoc[Enterprise security]
+| The power of a fully featured TigerGraph database as a fully managed service, in addition to the following:
 
-+ Security
+* Instant deployment
+* Automatic backups
+* Scaling out & replication
+* Automatic encryption at rest and in transit
+* Elastic read-only (ER) clusters
+* Start/stop on-demand - pay for what you use
 
-+ Pay for what you use
+|*Support*
+|
+* Community forums support for enterprise-free licenses.
+* Enterprise support for any paid enterprise licenses.
+* Add-on premium support available.
 
-|All TigerGraph Database and Enterprise features, including +
-+
-+ Distributed Graph +
-+
-+ MultiGraph +
-+
-+ Security +
-+
-+ User Management
+|* Community forums support for free-tier solutions.
+* Paid-tier solutions have 24X7 proactive monitoring and alert and basic enterprise support
+* Add-on premium support available.
 
-|*Support* |✅ |Free version includes support from the
-https://community.tigergraph.com/[Community Forum]. Contact us to get
-professional support.
-
-|*How to Get It*
-|https://www.tigergraph.com/cloud[www.tigergraph.com/cloud]
-|https://info.tigergraph.com/enterprise-free[www.tigergraph.com/free-trial]
 |===
-== Database Features
 
-[cols="<,^,^"]
+== Database features
+
+[cols="<,^,^",options="header"]
 |===
 | Feature | TigerGraph Cloud | Enterprise Edition
 
@@ -65,10 +72,6 @@ professional support.
 | *GSQL Query and Loading Language*  SQL-like syntax and built-in parallelism
 | ✅
 | ✅
-
-| *Graph Size*
-| Unlimited
-| Unlimited
 
 | *Compressed Data Store*
 | ✅
@@ -132,18 +135,14 @@ Design, Load, Explore, Query, Visualize
 | ✅
 |===
 
-== Security Features
+== Enterprise Security & Compliance
 
 [width="100%",cols="<34%,^33%,<33%",options="header",]
 |===
 |Feature |TigerGraph Cloud |Enterprise Edition
-|*Data Encryption* +
-+
-At Rest and In Motion |✅ |✅
-|*Enterprise User Management* +
-+
-LDAP and SSO |✅through GSQL web shell |✅
-|*Role-Based Access Control* |✅ |✅
+|At-rest encryption |✅ |✅
+|In-transit encryption|✅through GSQL web shell |✅
+| |✅ |✅
 |*Audit Compliance* |✅SOC 2 type 1 and type 2 |Coming soon
 a|
 *Cloud Security:*
@@ -152,3 +151,4 @@ VPC for each account
 
 |✅ |N/A
 |===
+

--- a/modules/intro/pages/comparison-of-editions.adoc
+++ b/modules/intro/pages/comparison-of-editions.adoc
@@ -1,8 +1,9 @@
 = Comparing TigerGraph Editions
+:description: Feature comparison of different TigerGraph editions.
 
 This document compares what is included in the Enterprise Edition vs. TigerGraph Cloud of the TigerGraph platform.
 
-To see what has been added or changed in different releases (versions) of TigerGraph, see xref:release-notes:change-log.adoc[Change Log].
+To see what has been added or changed in different releases (versions) of TigerGraph, see xref:release-notes:index.adoc[Change Log].
 
 == Overview
 [width="100%",cols="<34%a,<33%a,<33%a",options="header"]
@@ -55,7 +56,7 @@ The following options are available:
 
 [cols="<,^,^",options="header"]
 |===
-| Feature | TigerGraph Cloud | Enterprise Edition
+| Feature | Enterprise Edition | TigerGraph Cloud
 
 | *Native MPP Graph*
 | ✅
@@ -108,18 +109,18 @@ Design, Load, Explore, Query, Visualize
 
 [cols="<,^,^"]
 |===
-| *Feature* | TigerGraph Cloud | Enterprise Edition
+| *Feature* | Enterprise Edition | TigerGraph Cloud
 
 | *Automated Deployment*
-| ✅
 | No
+| ✅
 
 | *Automated Backups*
-| ✅
 | No
+| ✅
 
 | *Backup and Restore*
-| ✅ built-in cloud feature
+| ✅
 | ✅
 
 | *Multiple Users*
@@ -137,18 +138,14 @@ Design, Load, Explore, Query, Visualize
 
 == Enterprise Security & Compliance
 
-[width="100%",cols="<34%,^33%,<33%",options="header",]
+[cols="<,^,^"]
 |===
-|Feature |TigerGraph Cloud |Enterprise Edition
-|At-rest encryption |✅ |✅
-|In-transit encryption|✅through GSQL web shell |✅
-| |✅ |✅
-|*Audit Compliance* |✅SOC 2 type 1 and type 2 |Coming soon
-a|
-*Cloud Security:*
+|Feature |Enterprise edition |TigerGraph Cloud
 
-VPC for each account
-
-|✅ |N/A
+|*At-rest encryption* |✅ | ✅
+|*In-transit encryption*|✅ | ✅
+|*Multiple users* |✅ | ✅
+|*SOC 1* |✅ |Coming soon
+|*Network Security* |✅ |N/A
 |===
 


### PR DESCRIPTION
I didn't include the Deployment, Operations & Management section

I feel like those are a bit duplicated from the "Includes" row of an earlier section and mostly make Enterprise look hard to operate compared to Cloud. Let me know if you think  that section is really important and would still like to include it