### PR TITLE
removed double 'curl' in example

### DIFF
--- a/modules/API/pages/built-in-endpoints.adoc
+++ b/modules/API/pages/built-in-endpoints.adoc
@@ -3161,7 +3161,7 @@ Request::
 --
 [source.wrap,bash]
 ----
-curl -s -X GET curl -s -X GET "http://localhost:9000/query_result?requestid=196611.RESTPP_1_1.1630601692834.N"
+curl -s -X GET "http://localhost:9000/query_result?requestid=196611.RESTPP_1_1.1630601692834.N"
 ----
 --
 Response::


### PR DESCRIPTION
example has 
curl -s -X GET curl -s -X GET
should be
curl -s -X GET