### PR TITLE
Expire token removal doc 1344

### DIFF
--- a/modules/API/pages/built-in-endpoints.adoc
+++ b/modules/API/pages/built-in-endpoints.adoc
@@ -1113,6 +1113,9 @@ If not provided a request body, a request deletes all expired tokens.
 The secrets and users provided in the request body do not have to correlate with each other.
 A request deletes all tokens associated with any of the users and secrets contained in the payload.
 
+The request is atomic:
+if any of the provided users or secrets are invalid, or if a user doesn't have the privilege to remove tokens that belong to one of the users or secrets provided, no tokens will be removed by the request.
+
 ==== Parameters
 None.
 

--- a/modules/API/pages/built-in-endpoints.adoc
+++ b/modules/API/pages/built-in-endpoints.adoc
@@ -1074,25 +1074,48 @@ None.
 
 `DELETE :8123/expiredtoken`
 
-This endpoint removes all expired authentication tokens.
+This endpoint removes expired authentication tokens.
+A user is always allowed to remove their own expired tokens.
+If a user tries to delete tokens that belong to other users, they need to have xref:user-access:access-control-model.adoc#_privileges[the `WRITE_USER` privilege].
 
 ==== Sample request
 
-The following request deletes all expired tokens:
+The following request deletes all expired tokens.
+This request requires the privilege `WRITE_USER`:
 
 [.wrap,console]
 ----
-curl -X DELETE "localhost:8123/expiredtoken
+curl -X DELETE "https://localhost:8123/expiredtoken"
 ----
 
-The following request deletes all expried tokens of both users `u1` and `u2` created with secrets `s1` and `s2`.
+The following request deletes all expired tokens that belong to users `u1` and `u2` as well as all tokens created with secrets `s1` and `s2`.
+This request requires the privilege `WRITE_USER`
 
 [.wrap,console]
 ----
-curl -X DELETE "localhost:8123/expiredtoken?user=u1&user=u2&secret=s1&secret=s2
+curl -X DELETE 'localhost:8123/expiredtoken' -d '{"user":["u1","u2"],"secret":["s1","s2"]}'
 ----
+
+==== Request body
+The request body is optional.
+If not provided a request body, a request deletes all expired tokens.
+
+[.wrap,javascript]
+----
+{
+    "user": ["string"], <1>
+    "secret": ["string"] <2>
+}
+----
+<1> Users whose expired tokens to remove. Optional.
+<2> If a token is created with one of the secrets in the list, they are removed by the request. Optional.
+
+The secrets and users provided in the request body do not have to correlate with each other.
+A request deletes all tokens associated with any of the users and secrets contained in the payload.
 
 ==== Parameters
+None.
+
 
 
 

--- a/modules/API/pages/built-in-endpoints.adoc
+++ b/modules/API/pages/built-in-endpoints.adoc
@@ -1070,6 +1070,32 @@ Response::
 
 None.
 
+=== Remove expired tokens
+
+`DELETE :8123/expiredtoken`
+
+This endpoint removes all expired authentication tokens.
+
+==== Sample request
+
+The following request deletes all expired tokens:
+
+[.wrap,console]
+----
+curl -X DELETE "localhost:8123/expiredtoken
+----
+
+The following request deletes all expried tokens of both users `u1` and `u2` created with secrets `s1` and `s2`.
+
+[.wrap,console]
+----
+curl -X DELETE "localhost:8123/expiredtoken?user=u1&user=u2&secret=s1&secret=s2
+----
+
+==== Parameters
+
+
+
 == Loading jobs
 
 === Run a Loading Job

--- a/modules/cluster-resizing/pages/expand-a-cluster.adoc
+++ b/modules/cluster-resizing/pages/expand-a-cluster.adoc
@@ -48,7 +48,6 @@ $ gadmin cluster expand m3:10.128.0.81,m4:10.128.0.82 --ha 1
 
 We suggest naming the new nodes following the convention of `m<serial>`, such as `m1`, `m2`, and `m3` for a 3-node cluster. If you are adding a fourth node, then the fourth node would be named `m4`. If you decide to name them differently, make sure that all names are unique within the cluster.
 
-[discrete]
 ==== Supply a staging location
 
 Extra disk space is required during cluster expansion. If more space is not available on the same disk, you can supply a staging location on a different disk to hold temporary data:

--- a/modules/cluster-resizing/pages/repartition-a-cluster.adoc
+++ b/modules/cluster-resizing/pages/repartition-a-cluster.adoc
@@ -38,7 +38,6 @@ For example, assume you begin with a 5-node cluster with a replication factor of
 Changing the replication factor to 2 without adding new nodes will change the distribution of your cluster to be 2*2, with one node being left idle.
 To avoid nodes being left idle, ensure that you pick a replication factor that can cleanly divide the total number of nodes you have in the cluster.
 
-[discrete]
 ==== Supply a staging location
 
 Extra disk space is required during cluster repartition. If more space is not available on the same disk, you can supply a staging location on a different disk to hold temporary data:

--- a/modules/cluster-resizing/pages/shrink-a-cluster.adoc
+++ b/modules/cluster-resizing/pages/shrink-a-cluster.adoc
@@ -45,7 +45,6 @@ $ gadmin cluster shrink node_ip_list [--ha <replication_factor>]
 $ gadmin cluster shrink m3:10.128.0.81,m4:10.128.0.82 --ha 1
 ----
 
-[discrete]
 ==== Supply a staging location
 
 Extra disk space is required during cluster shrinking. If more space is not available on the same disk, you can supply a staging location on a different disk to hold temporary data:


### PR DESCRIPTION
The option to provide users and secrets through query string parameters is omitted because of security concerns. I feel like we might end up removing the ability to do this at all in the future so it's best not to document it now in case we have to deprecate it. 