### PR TITLE
Update default value for ack in RESTPP POST

### DIFF
--- a/modules/API/pages/upsert-rest.adoc
+++ b/modules/API/pages/upsert-rest.adoc
@@ -25,7 +25,7 @@ acknowledged the POST request
 * `"none"`: request will return immediately after
 RESTPP processed the POST request.
 
-Default value is `"all"`. `"none"` is not recommended except in very specific cases as it could easily lead to overwhelming the system. 
+Default value is `"all"`. `"none"` is not recommended as it could easily lead to overwhelming the system. Contact TigerGraph Support if you believe your situation requires setting this to "none".
 
 |`new_vertex_only` |No |If `new_vertex_only` is set to true, the request will only insert new
 vertices and not update existing ones.

--- a/modules/API/pages/upsert-rest.adoc
+++ b/modules/API/pages/upsert-rest.adoc
@@ -25,7 +25,7 @@ acknowledged the POST request
 * `"none"`: request will return immediately after
 RESTPP processed the POST request.
 
-Default value is `"none"`.
+Default value is `"all"`. `"none"` is not recommended except in very specific cases as it could easily lead to overwhelming the system. 
 
 |`new_vertex_only` |No |If `new_vertex_only` is set to true, the request will only insert new
 vertices and not update existing ones.


### PR DESCRIPTION
Details based on discussion in EngineTeam Zulip stream: https://zulip.graphtiger.com/#narrow/stream/322-EngineTeam/topic/.28no.20topic.29/near/2471352 Per Songting, none should rarely be used and all is the default value in the code.