### PR TITLE
remove references to FreshDesk

### DIFF
--- a/modules/installation/pages/upgrade.adoc
+++ b/modules/installation/pages/upgrade.adoc
@@ -49,7 +49,7 @@ Support team.
 Upgrading the Developer Edition or migrating to another edition are not supported.
 
 For detailed upgrade procedures, see our support article on the
-link:https://tigergraph.freshdesk.com/support/solutions/articles/5000859240-2-x-to-3-0-0-upgrade-flow[2.6.x to 3.x upgrade flow]
+link:https://tigergraph.zendesk.com/hc/en-us/articles/8173584319892-2-6-x-to-3-x-upgrade-flow[2.6.x to 3.x upgrade flow]
 
 [[upgrading-cloud-marketplace-image]]
 == Upgrading Cloud Marketplace images

--- a/modules/intro/pages/release-process.adoc
+++ b/modules/intro/pages/release-process.adoc
@@ -89,7 +89,7 @@ They could be universal, applicable to all customers, or specific, applicable to
 
 === Support
 
-Customers who need assistance can open a support ticket at http://tigergraph.freshdesk.com[tigergraph.freshdesk.com] or https://tigergraph.zendesk.com/hc/en-us/[open a support ticket].
+Customers who need assistance can open a support ticket at https://tigergraph.zendesk.com/hc/en-us/[TigerGraph's ZenDesk Portal].
 
 == Managed Service
 

--- a/modules/system-management/pages/management-with-gadmin.adoc
+++ b/modules/system-management/pages/management-with-gadmin.adoc
@@ -36,4 +36,4 @@ See xref:reference:configuration-parameters.adoc[] for a full list of these para
 
 == Nginx configuration
 
-Follow the steps documented in https://tigergraph.freshdesk.com/support/solutions/articles/5000867964-change-default-value-for-fastcgi-read-timeout-nginx-configuration-[this support article] to update the Nginx configurations of your TigerGraph instance.
+Follow the steps documented in https://kb.tigergraph.com/knowledge_base/v3/how_to_articles/how_to_create_an_nginx_configuration_template[this support article] to update the Nginx configurations of your TigerGraph instance.

--- a/modules/troubleshooting/nav.adoc
+++ b/modules/troubleshooting/nav.adoc
@@ -1,5 +1,5 @@
 * Troubleshooting
-** link:https://tigergraph.freshdesk.com/support/solutions[Knowledge base and FAQs]
+** link:https://kb.tigergraph.com/[Knowledge base and FAQs]
 ** xref:system-administration-faqs.adoc[]
 ** xref:log-files.adoc[]
 *** xref:audit-logs.adoc[]


### PR DESCRIPTION
We are no longer user FreshDesk. Removed old references and replaced with either kb.tigergraph.com or ZenDesk links. 