### PR TITLE
DOC-1642 respectful terminology, DOC-1678 HA GSQL wording

### DIFF
--- a/modules/ha/pages/ha-for-gsql-server.adoc
+++ b/modules/ha/pages/ha-for-gsql-server.adoc
@@ -305,7 +305,7 @@ CREATE LOADING JOB load_kafka FOR GRAPH poc_graph {
 
 === GSQL Client connection setup
 
-The GSQL client can connect to the GSQL server in one of several ways according to following priority order:
+The GSQL client can connect to the GSQL server in one of several ways according to the following priority order:
 
 ==== Using IP address
 

--- a/modules/ha/pages/ha-for-gsql-server.adoc
+++ b/modules/ha/pages/ha-for-gsql-server.adoc
@@ -1,14 +1,9 @@
 = High Availability Support for GSQL Server
 :description: High availability overview for the GSQL server.
 
-TigerGraph has built-in HA for all the internal critical components from the beginning.
-This includes GPE, GSE, REST API Servers, etc.
-However, the user-facing applications (GSQL and GraphStudio) were designed to be set up by customers based on their High Availability (HA) needs.
-This included building solutions using non-TigerGraph components.
-
-TigerGraph supports native HA functionality for user-facing applications as well.
-This simplifies and streamlines HA deployment for users completely.
-For Operations personnel, this reduces the operational overhead while enhancing the availability for end users.
+TigerGraph has built-in HA for all the internal critical components.
+This includes GPE, GSE, and REST API Servers.
+The GSQL Server also has built-in HA, but as it is a user-facing component, its HA configuration can be customized by users.
 
 == Design overview
 
@@ -23,9 +18,9 @@ image::gsql-ha.png[Diagram visualizing the architecture of a TigerGraph cluster 
 
 The primary GSQL server performs the following tasks:
 
-* Process client connections
-* Process querying requests from GSQL clients
-* Process user management requests
+* Processes client connections
+* Processes query requests from GSQL clients
+* Processes user management requests
 
 When the primary server fails, a standby server becomes the new primary server.
 When the old primary server is restored, it becomes a GSQL standby server.
@@ -33,9 +28,10 @@ When the old primary server is restored, it becomes a GSQL standby server.
 === Role of standby GSQL servers
 
 * Redirect requests to the primary server
-* Help the primary server check for source data file existence and parse file header (if ANY is chosen)
+* Help the primary server check for the existence of source data files and parse file headers (if ANY is chosen)
 
 == Configuring HA for the GSQL server
+=== Configuring the number of GSQL servers
 The GSQL server (`gsql`) runs on the first 5 nodes in a cluster by default.
 However, you can increase the number of servers through the `GSQL.BasicConfig.Nodes` configuration parameter.
 
@@ -73,7 +69,7 @@ In some cases with large query results, you may get an error when the results ar
 Error forwarding request to GSQL leader!
 IOException: Truncated chunk
 ----
-
+f
 To fix this, use the xref:reference:configuration-parameters.adoc[configuration parameter] `GSQL.HA.BufferedReaderBufferSizeBytes` to increase the size of the buffer.
 Restart GSQL after updating the buffer size.
 
@@ -86,19 +82,34 @@ gadmin restart gsql
 In this example, the buffer size has been set to around two gigabytes compared to the default value of eight kilobytes.
 Different datasets and queries will require different buffer sizes.
 
+=== Setting GSQL HA Failover
+
+Use the `gadmin config` command to get/set the following configurations related to GSQL High Availability.
+
+The first is the heartbeat interval in milliseconds. The second is the number of consecutively missed heartbeats that will trigger switching to a backup server.
+It must be at least 2 to allow 1 heartbeat miss.
+
+[source,text]
+----
+Controller.LeaderElectionHeartBeatIntervalMS = 2000
+Controller.LeaderElectionHeartBeatMaxMiss = 4
+----
+
+For example, if we use `LeaderElectionHeartBeatIntervalMS = 2000` and `LeaderElectionHeartBeatMaxMiss = 4` as shown above, then the total timeout is 2 × 4 = 8 seconds.
+In this case, the current primary server will be switched if its heartbeat has stopped for more than 8 seconds.
+
 
 == User Impact and Changes
 
-=== UDF and token function maintenance
+=== UDF and token function retrieval
 
-Users store the following data on node m1 that is needed for query execution.
-This is part of the user source code that TigerGraph system uses to compile.:
+The m1 node of a cluster stores the following files that may contain user-defined C++ functions to customize GSQL:
 
 * GSQL loader's Token functions
 * ExprFunctions
 * ExprUtil
 
-GSQL server will retrieve the User source code files in the following priority order when it needs them:
+The GSQL server will retrieve these user source code files in the following priority order when it needs them:
 
 * Via GitHub/GitHub enterprise (if configuration is set),
 * Files uploaded via `PUT` commands
@@ -106,14 +117,14 @@ GSQL server will retrieve the User source code files in the following priority o
 
 ==== User source code in GitHub code repository
 
-This requires public network access or GitHub enterprise server access.
-Provide the following gadmin configuration:
+This mode requires public network access or GitHub enterprise server access.
+Provide the following `gadmin` configuration:
 
 [source,text]
 ----
 GSQL.GithubUserAcessToken # the credential, or "anonymous", empty means not using github
 GSQL.GithubRepository     # e.g. tigergraph/ecosys
-GSQL.GithubBranch         # optional, o/w use "master" branch, e.g. demo_github
+GSQL.GithubBranch         # optional; default is "main" branch, e.g. demo_github
 GSQL.GithubPath           # path to the directory in the github that has TokenBank.cpp, ExprFunctions.hpp, ExprUtil.hpp, e.g. sample_code/src
 GSQL.GithubUrl            # optional, used for github enterprise, e.g. https://api.github.com
 ----
@@ -129,14 +140,9 @@ gadmin config set GSQL.GithubPath sample_code/src
 gadmin config apply
 ----
 
-When GSQL server needs to compile the files, it will retrieve them from GitHub if the GitHub access is configured as above.
+When the GSQL server needs to compile the files, it will retrieve them from GitHub if the GitHub access is configured as above.
 It will retry 3 times, with a five-second timeout each time.
 If the connection fails, it will go to the next priority level method, i.e. file uploaded via `PUT` commands.
-
-==== User Source code maintenance for local files in the cluster
-
-We are introducing new GSQL commands to address this need.
-These commands will allow users to upload and download the user source files.
 
 *Upload source code*
 
@@ -264,7 +270,7 @@ $(gadmin config get System.AppRoot)/dev/gdk/gsql/src/QueryUdf/ExprFunctions.hpp
 
 Before TigerGraph version 3.1, the file path used in loading jobs referred to the file in m1, unless the user specified the machine name before the path `(ALL, ANY, m1, m2,...)`. 
 Now, the primary server can be running on any machine, and can be switched. 
-This means the GSQL server may or may not find the file. To be backwards-compatible with previous versions of TigerGraph, prefix a machine name if the client is in TigerGraph cluster.
+This means the GSQL server may or may not find the file. To be backwards-compatible with previous versions of TigerGraph, prefix a machine name if the client is in the TigerGraph cluster.
 
 Users can specify the node ID before the path using `ALL, ANY, m1, m2` and so on. 
 Declaring ALL or ANY as host ID will load files from every cluster node.
@@ -299,18 +305,18 @@ CREATE LOADING JOB load_kafka FOR GRAPH poc_graph {
 
 === GSQL Client connection setup
 
-The GSQL client can connect to GSQL server in the different ways with the following priority order:
+The GSQL client can connect to the GSQL server in one of several ways according to following priority order:
 
 ==== Using IP address
 
-Users can specify the ip and port when calling the GSQL client using `gsql -i` or `gsql -ip`. For example:
+Users can specify the IP address and port when calling the GSQL client using `gsql -i` or `gsql -ip`. For example:
 
 [source,text]
 ----
 gsql -ip 192.168.11.32:14240,192.168.11.34:14240,192.168.11.36
 ----
 
-The GSQL clients will try these IPs and ports one by one. The port is optional. Port `14240`, the default port for GSQL server, will be used if no port is specified.
+The GSQL clients will try these IPs and ports one by one. The port is optional. Port `14240`, the default port for the GSQL server, will be used if no port is specified.
 
 ==== Using GSQL IP Configuration
 
@@ -326,19 +332,3 @@ The port number is also optional here, using `14240` by default.
 ==== Using default local server
 
 If  `gsql -i` or `gsql -ip` are not used, and the file `gsql_server_ip_config` does not exist where `gsql` is called, the GSQL client will try to connect to the local server at `127.0.0.1:8123`.
-
-=== Setting GSQL HA Configuration
-
-Use the `gadmin config` command to get/set the following configurations related to GSQL High Availability.
-
-The first is the heartbeat interval in milliseconds. The second (`max misses`) is the total timeout for switching to the primary server which will measure the number of heartbeat intervals.
-It must be at least 2 to allow 1 heartbeat miss.
-
-[source,text]
-----
-Controller.LeaderElectionHeartBeatIntervalMS = 2000
-Controller.LeaderElectionHeartBeatMaxMiss = 4
-----
-
-For example, if we use `IntervalMS = 2000` and `max misses = 4` as shown above, then the total timeout is 2 × 4 = 8 seconds.
-In this case, the current primary server will be switched if its heartbeat has stopped for more than 8 seconds.

--- a/modules/user-access/pages/vlac.adoc
+++ b/modules/user-access/pages/vlac.adoc
@@ -91,7 +91,7 @@ CREATE SCHEMA_CHANGE JOB add_tags {
   ADD TAG public DESCRIPTION "Open for public";
   ADD TAG tech DESCRIPTION "All about technology";
   ADD TAG vip DESCRIPTION "Very Important Person";
-  ADD TAG dummy DESCRIPTION "Yeah, just a dummy";
+  ADD TAG default DESCRIPTION "Just a default";
 }
 RUN SCHEMA_CHANGE JOB add_tags
 ----
@@ -108,7 +108,7 @@ Tags:
 - TAG public DESCRIPTION "Open for public"
 - TAG tech DESCRIPTION "All about technology"
 - TAG vip DESCRIPTION "Very Important Person"
-- TAG dummy DESCRIPTION "Yeah, just a dummy"
+- TAG default DESCRIPTION "Just a default"
 ----
 
 === Drop a tag
@@ -130,10 +130,10 @@ Like `ADD TAG`, `DROP TAG` also needs to be inside a `SCHEMA_CHANGE JOB`:
 ----
 USE GRAPH socialNet
 
-CREATE SCHEMA_CHANGE JOB drop_dummy_tag {
-  DROP TAG dummy;
+CREATE SCHEMA_CHANGE JOB drop_default_tag {
+  DROP TAG default;
 }
-RUN SCHEMA_CHANGE JOB drop_dummy_tag
+RUN SCHEMA_CHANGE JOB drop_default_tag
 ----
 
 [NOTE]
@@ -203,10 +203,10 @@ To describe a combination of tags, use the `&` operator to combine the tags:
 [source,gsql]
 ----
 USE GRAPH socialNet
-CREATE GRAPH mixedNet AS socialNet(person:public&vip, post:public&tech&dummy, friend, posted, liked)
+CREATE GRAPH mixedNet AS socialNet(person:public&vip, post:public&tech&default, friend, posted, liked)
 ----
 
-The graph `mixedNet` will only include the `person` vertices having both the `public` and ``vip``tags, and posts having all three of the `public` , `tech` and `dummy` tags.
+The graph `mixedNet` will only include the `person` vertices having both the `public` and ``vip``tags, and posts having all three of the `public` , `tech` and `default` tags.
 
 *Same tag for all vertex types*
 


### PR DESCRIPTION
Significant changes on the HA for GSQL Server page:
1. Rewrote the intro which was confusing and dated. I _think_ my new version is factually correct.
2. Moved a section from the bottom to the middle, to be a part of "GSQL Server HA Configuration".
3. Dropped a subsection that said (I think, because it was poorly worded) "We're going to add support for (local file something-or-other)", but we don't have that feature yet.

The Terminology change was changing "dummy" to "default".