### PR TITLE
Fix admin table structural error

### DIFF
--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -11,7 +11,7 @@ See xref:system-management:management-with-gadmin.adoc[] for how to set a parame
 |Name |Description |Example
 |Admin.BasicConfig.Env
 |The runtime environment variables, separated by
-`;`
+`;` |`LD_LIBRARY_PATH=$LD_LIBRARY_PATH;`
 
 
 |Admin.BasicConfig.LogConfig.LogFileMaxDurationDay |The maximum number


### PR DESCRIPTION
Restore a cell that was accidentally deleted from the Admin table, which misaligned the entire table.