### PR TITLE
Doc 1705 kubernetes is preview

### DIFF
--- a/modules/kubernetes/nav.adoc
+++ b/modules/kubernetes/nav.adoc
@@ -1,5 +1,5 @@
-* xref:index.adoc[]
-** xref:k8s-operator/index.adoc[]
+* xref:index.adoc[Kubernetes (Preview)]
+** xref:k8s-operator/index.adoc[Kubernetes Operator (Preview)]
 *** xref:k8s-operator/installation.adoc[]
 *** xref:k8s-operator/cluster-operations.adoc[]
 *** xref:k8s-operator/connect-to-cluster.adoc[]

--- a/modules/kubernetes/pages/expansion.adoc
+++ b/modules/kubernetes/pages/expansion.adoc
@@ -1,6 +1,8 @@
-= Expand a Cluster - Kubernetes
+= Expand a Cluster - Kubernetes Classic
 :description: This page provides instructions on how to expand a Kubernetes TigerGraph cluster.
 :sectnums:
+
+WARNING: This feature is part of our Kubernetes Classic support, which is now deprecated.  New designs should not use this feature.
 
 Like regular TigerGraph clusters, a TigerGraph cluster deployed on Kubernetes can also be expanded.
 When you expand a TigerGraph cluster on Kubernetes, the data across the different nodes are automatically redistributed.

--- a/modules/kubernetes/pages/index.adoc
+++ b/modules/kubernetes/pages/index.adoc
@@ -7,6 +7,8 @@ You can deploy TigerGraph single servers and clusters using Kubernetes on any cl
 
 TigerGraph provides its custom Kubernetes Operator to help you automate TigerGraph operations such as the creation, status checking and deletion of TigerGraph clusters.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
+
 xref:k8s-operator/index.adoc[Kubernetes Operator Overview]
 
 The Operator provides two main benefits over Kubernetes Classic:

--- a/modules/kubernetes/pages/k8s-operator/backup-and-restore.adoc
+++ b/modules/kubernetes/pages/k8s-operator/backup-and-restore.adoc
@@ -5,6 +5,7 @@ The Backup and Restore functionality of the Kubernetes operator allows for sched
 Backup and restore jobs work by internally creating TigerGraphBackup, TigerGraphRestore, and TigerGraphScheduledBackup functions that carry out jobs according to the user settings.
 This concept is important for understanding the relationship between the console commands you enter and the results from Kubernetes.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
 
 == Prerequisites
 

--- a/modules/kubernetes/pages/k8s-operator/cluster-operations.adoc
+++ b/modules/kubernetes/pages/k8s-operator/cluster-operations.adoc
@@ -6,6 +6,8 @@ This page describes the steps to perform the following operations using the Tige
 In Kubernetes, you provision resources such as TigerGraph clusters by creating a Deployment.
 Depending on the context, this document may refer to creating a cluster by creating a Deployment.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
+
 [#_create_tigergraph_clusters]
 == Create TigerGraph clusters
 

--- a/modules/kubernetes/pages/k8s-operator/connect-to-cluster.adoc
+++ b/modules/kubernetes/pages/k8s-operator/connect-to-cluster.adoc
@@ -3,6 +3,8 @@
 
 This page describes the steps to connect to a TigerGraph cluster created by the TigerGraph Kubernetes Operator.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
+
 == Establish an SSH connection to the cluster
 
 To gain shell access to your cluster, run the following command:

--- a/modules/kubernetes/pages/k8s-operator/index.adoc
+++ b/modules/kubernetes/pages/k8s-operator/index.adoc
@@ -6,6 +6,8 @@ It enables you to automate operations such as the creation, status checking, res
 
 By reducing the complexity of running a TigerGraph cluster, it lets you focus on the desired state of your clusters and saves you time from the details of manual deployment and life-cycle management.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
+
 The Operator provides the following features:
 
 * xref:k8s-operator/cluster-operations.adoc#_create_tigergraph_clusters[Cluster provisioning]

--- a/modules/kubernetes/pages/k8s-operator/installation.adoc
+++ b/modules/kubernetes/pages/k8s-operator/installation.adoc
@@ -4,6 +4,8 @@
 
 This page describes the steps to install and uninstall the TigerGraph Kubernetes Operator on your Kubernetes cluster.
 
+IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.
+
 NOTE: The Operator only needs to be installed once for each cluster.
 If you run into errors saying that Custom Resource Definition (CRD) already exists, it is likely that someone else who has access to your cluster has already installed the operator.
 Therefore, you can safely ignore the error and skip installation.

--- a/modules/kubernetes/pages/shrinking.adoc
+++ b/modules/kubernetes/pages/shrinking.adoc
@@ -1,6 +1,8 @@
-= Shrink a Cluster - Kubernetes
+= Shrink a Cluster - Kubernetes Classic
 :description: This page provides instructions on how to expand a Kubernetes TigerGraph cluster.
 :sectnums:
+
+WARNING: This feature is part of our Kubernetes Classic support, which is now deprecated.  New designs should not use this feature.
 
 Like regular TigerGraph clusters, a TigerGraph cluster deployed on Kubernetes can also be shrunk.
 When you shrink a TigerGraph cluster on Kubernetes, the data across the different nodes are automatically redistributed.

--- a/modules/kubernetes/pages/upgrade.adoc
+++ b/modules/kubernetes/pages/upgrade.adoc
@@ -1,6 +1,8 @@
-= Upgrade a Cluster - Kubernetes
+= Upgrade a Cluster - Kubernetes Classic
 :description: Instructions to upgrade a TigerGraph cluster deployed on Kubernetes.
 :sectnums:
+
+WARNING: This feature is part of our Kubernetes Classic support, which is now deprecated.  New designs should not use this feature.
 
 This page walks you through upgrading a TigerGraph cluster in Kubernetes.
 Upgrading a cluster requires several minutes of downtime.


### PR DESCRIPTION
For at least one of you to review and approve (@chengjie-qin , @ElliotMtg2011, @arunramasami ):

1. In left-hand nav menu: Change “Kubernetes” to “Kubernetes (Preview)” and “Kubernetes Operator” to “Kubernetes Operator (Preview)” [Kubernetes Operator - TigerGraph Server](https://docs.tigergraph.com/tigergraph-server/3.9/kubernetes/k8s-operator/) 

2. For the pages that are part of the Kubernetes Operator support, add 
  a. `IMPORTANT: Kubernetes Operator support is currently a Preview Feature. Preview Features give users an early look at future production-level features. Preview Features should not be used for production deployments.`

3. For the pages that are part of the Kubernetes Classic support
  a. Change the page title to include “Kubernetes Classic”
  b. Add
`WARNING: This feature is part of our Kubernetes Classic support, which is now deprecated. New designs should not use this feature.`