### PR TITLE
DOC-1864-Added-3.9.2-1ReleaseNotes

### DIFF
--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -133,7 +133,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 ==== Functionality
 * Fixed data inconsistency while loading data and post-processing operations
 via write queries when running `data_consistency_check` with GPE and GSE.
-* Fixed command fail when user with only graph scope privilege runs a command that only requires graph scope privilege.
+* Fixed `GRAPH` scope command failure due to missing privilege check in v3.9.2. 
 * Fixed failure to compile query when using edge variables in DML-sub delete statement.
 * Fixed `subtypeid` error message inconsistency.
 * Fixed `/deleted_vertex_check` false alert when GSE doesn't have a segment.

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -128,7 +128,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 * Fixed GPE crash caused by aborted query still being used by running thread.
 * Fixed crash issue after RESTPP auth refresh.
 * Fixed GSE crash due to check failure when refreshing leader info after 60 minute timeout.
-* Fixed GPE crash and non-recovery due to Kafka retention to a higher offset.
+* Fixed GPE crash and non-recovery due to Kafka and GPE offset comparison misread after GPE delta topic on related nodes were deleted.
 
 ==== Functionality
 * Fixed data inconsistency while loading data and post-processing operations

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -132,7 +132,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 
 ==== Functionality
 * Fixed data inconsistency while loading data and post-processing operations
-via write queries when running `data_consitency_check` with GPE and GSE.
+via write queries when running `data_consistency_check` with GPE and GSE.
 * Fixed command fail when user with only graph scope privilege runs a command that only requires graph scope privilege.
 * Fixed failed to compile query when using edge variables in DML-sub delete statement.
 * Fixed `subtypeid` error message inconsistency for GPR and interpret mode.

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -134,7 +134,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 * Fixed data inconsistency while loading data and post-processing operations
 via write queries when running `data_consistency_check` with GPE and GSE.
 * Fixed command fail when user with only graph scope privilege runs a command that only requires graph scope privilege.
-* Fixed failed to compile query when using edge variables in DML-sub delete statement.
+* Fixed failure to compile query when using edge variables in DML-sub delete statement.
 * Fixed `subtypeid` error message inconsistency for GPR and interpret mode.
 * Fixed `/deleted_vertex_check` false alert when GSE doesn't have a segment.
 

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -132,7 +132,6 @@ vertex function can also be used with vertex input parameters in the query-body 
 
 ==== Functionality
 * Fixed data inconsistency when GSE consumed deletion requests from Kafka on update of `committed_next_id_map`
-via write queries when running `data_consistency_check` with GPE and GSE.
 * Fixed `GRAPH` scope command failure due to missing privilege check in v3.9.2. 
 * Fixed failure to compile query when using edge variables in DML-sub delete statement.
 * Fixed `subtypeid` error message inconsistency.

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -128,7 +128,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 * Fixed GPE crash caused by aborted query still being used by running thread.
 * Fixed crash issue after RESTPP auth refresh.
 * Fixed GSE crash due to check failure when refreshing leader info after 60 minute timeout.
-* Fixed GPE crash and non-recovery due to Kafka and GPE offset when related nodes were deleted.
+* Fixed GPE crash and non-recovery due to Kafka and GPE offset when adjacent vertices were deleted.
 
 ==== Functionality
 * Fixed data inconsistency when GSE consumed deletion requests from Kafka on update of `committed_next_id_map`

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -135,7 +135,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 via write queries when running `data_consistency_check` with GPE and GSE.
 * Fixed command fail when user with only graph scope privilege runs a command that only requires graph scope privilege.
 * Fixed failure to compile query when using edge variables in DML-sub delete statement.
-* Fixed `subtypeid` error message inconsistency for GPR and interpret mode.
+* Fixed `subtypeid` error message inconsistency.
 * Fixed `/deleted_vertex_check` false alert when GSE doesn't have a segment.
 
 ==== Security

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -128,7 +128,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 * Fixed GPE crash caused by aborted query still being used by running thread.
 * Fixed crash issue after RESTPP auth refresh.
 * Fixed GSE crash due to check failure when refreshing leader info after 60 minute timeout.
-* Fixed GPE crash and non-recovery due to Kafka and GPE offset comparison misread after GPE delta topic on related nodes were deleted.
+* Fixed GPE crash and non-recovery due to Kafka and GPE offset when related nodes were deleted.
 
 ==== Functionality
 * Fixed data inconsistency when GSE consumed deletion requests from Kafka on update of `committed_next_id_map`

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -122,6 +122,28 @@ vertex function can also be used with vertex input parameters in the query-body 
 
 == Fixed issues
 
+=== Fixed and Improved in 3.9.2-1
+
+==== Crashes and Deadlocks
+* Fixed a GPE crash caused by aborted query still being used by running thread.
+* Fixed crash issue after RESTPP auth refresh.
+* Fixed GSE crash due to the check failure when refreshing leader info after 60 minute timeout.
+* Fixed GPE crash and non-recovery due to Kafka retention to a higher offset.
+
+==== Functionality
+* Fixed data inconsistency while loading data and post-processing operations
+via write queries when running `data_consitency_check` with GPE and GSE.
+* Fixed command fail when user with only graph scope privilege runs a command that only requires graph scope privilege.
+* Fixed failed to compile query when using edge variables in DML-sub delete statement.
+* Fixed `subtypeid` error message inconsistency for GPR and interpret mode.
+* Fixed `/deleted_vertex_check` false alert when GSE doesn't have a segment.
+
+==== Security
+* Security: Updated JDK to 11.0.20 to address vulnerability scan issues.
+
+==== Performance
+* Improved performance of GPE abort function.
+
 === Fixed and Improved in 3.9.2
 
 ==== Crashes and Deadlocks

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -131,7 +131,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 * Fixed GPE crash and non-recovery due to Kafka and GPE offset comparison misread after GPE delta topic on related nodes were deleted.
 
 ==== Functionality
-* Fixed data inconsistency while loading data and post-processing operations
+* Fixed data inconsistency when GSE consumed deletion requests from Kafka on update of `committed_next_id_map`
 via write queries when running `data_consistency_check` with GPE and GSE.
 * Fixed `GRAPH` scope command failure due to missing privilege check in v3.9.2. 
 * Fixed failure to compile query when using edge variables in DML-sub delete statement.

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -127,7 +127,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 ==== Crashes and Deadlocks
 * Fixed GPE crash caused by aborted query still being used by running thread.
 * Fixed crash issue after RESTPP auth refresh.
-* Fixed GSE crash due to the check failure when refreshing leader info after 60 minute timeout.
+* Fixed GSE crash due to check failure when refreshing leader info after 60 minute timeout.
 * Fixed GPE crash and non-recovery due to Kafka retention to a higher offset.
 
 ==== Functionality

--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -125,7 +125,7 @@ vertex function can also be used with vertex input parameters in the query-body 
 === Fixed and Improved in 3.9.2-1
 
 ==== Crashes and Deadlocks
-* Fixed a GPE crash caused by aborted query still being used by running thread.
+* Fixed GPE crash caused by aborted query still being used by running thread.
 * Fixed crash issue after RESTPP auth refresh.
 * Fixed GSE crash due to the check failure when refreshing leader info after 60 minute timeout.
 * Fixed GPE crash and non-recovery due to Kafka retention to a higher offset.


### PR DESCRIPTION
Added section (below) to server-docs release notes for upcoming release of 3.9.2-1 (pertains to these [11 tickets](https://graphsql.atlassian.net/issues/?jql=labels%20%3D%20%22tg_3.9.2-1%22%20%26%20labels%20%3D%20doc_392-1)


Link to Jira issue : https://graphsql.atlassian.net/browse/DOC-1864 