### PR TITLE
DOC-1855-Fix-OAuthSSOToSAML2

### DIFF
--- a/modules/user-access/pages/enabling-user-authentication.adoc
+++ b/modules/user-access/pages/enabling-user-authentication.adoc
@@ -56,7 +56,7 @@ To enable RESTPP authentication, set the `RESTPP.Factory.EnableAuth` parameter t
 
 . As the TigerGraph Linux user, run the following command:
 +
-.Enabling REST{pp} OAuth Authentication
+.Enabling REST{pp} SAML2.0 Authentication
 +
 [source,bash]
 ----
@@ -67,7 +67,7 @@ $ gadmin config set RESTPP.Factory.EnableAuth true
 
 . Run the following commands to save the configuration and restart system services:
 +
-.Enabling REST{pp} OAuth Authentication
+.Enabling REST{pp} SAML2.0 Authentication
 +
 [source,bash]
 ----


### PR DESCRIPTION
Fixed misleading OAuth to reflect accurate SAML2.0 **_*This will need to be cherry picked or updated to reflected across all versions_**. (3.9LTS, 3.8, 3.7, 3.6 LTS, 3.5, 3.4, 3.3, 3.2)


<img width="687" alt="Screen Shot 2023-09-20 at 10 34 32 AM" src="https://github.com/tigergraph/server-docs/assets/144745015/2ce98c57-003a-4417-8d10-198f183974d5">





