### PR TITLE
Doc 1853 added RedHat 8.7 to 8.8 to version LTS3.6 Docs

### DIFF
--- a/modules/installation/pages/hw-and-sw-requirements.adoc
+++ b/modules/installation/pages/hw-and-sw-requirements.adoc
@@ -51,6 +51,7 @@ The software has been tested on the operating systems listed below:
 .List of supported OS
 * RedHat 7.0 to 7.9 (x64)
 * RedHat 8.0 to 8.6 (x64)
+* RedHat 8.7 to 8.8 (x64)
 * Centos 7.0 to 7.4 (x64)
 * Centos 8.0 to 8.2 (x64)
 * Ubuntu 16.04 LTS, Ubuntu 18.04 LTS, Ubuntu 20.04 LTS


### PR DESCRIPTION
Added "RedHat 8.7 to 8.8" to the list of "certified operating systems" in LTS3.6. **Will also update corresponding list in 3.9.2 docs**