### PR TITLE
DOC-1853 added RedHat 8.8 to LTS3.9.2

### DIFF
--- a/modules/installation/pages/hw-and-sw-requirements.adoc
+++ b/modules/installation/pages/hw-and-sw-requirements.adoc
@@ -23,7 +23,7 @@ The software has been tested on the operating systems listed below:
 |===
 | Distro | Supported
 
-| RedHat 7.0 to 8.7
+| RedHat 7.0 to 8.8
 | ✓
 
 | CentOs 6.5 to 8.0


### PR DESCRIPTION
Added "RedHat 8.8" to the list of "certified operating systems" in LTS3.9.2. Will also update corresponding list in 3.9.2 docs