### PR TITLE
DOC-1862-fixed-5ClusterMaxTo3Cluster

### DIFF
--- a/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
+++ b/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
@@ -5,7 +5,7 @@
 TigerGraph supports native HA functionality for its application server, which serves the APIs for TigerGraph's GUI - GraphStudio and Admin Portal.
 The application server follows the active-active architecture, and runs on the *first three nodes* in a cluster by default.
 
-NOTE: _**Three ** is the maximum number of application servers per cluster.
+NOTE: _Three is the maximum number of application servers per cluster.
 If one server falls offline, you can use the other servers without any loss of functionality._
 
 When you deploy TigerGraph in a cluster with multiple replicas, it is ideal to set up load balancing to distribute network traffic evenly across the different servers.

--- a/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
+++ b/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
@@ -3,7 +3,7 @@
 :description: Overview of high availability support for the application server.
 
 TigerGraph supports native HA functionality for its application server, which serves the APIs for TigerGraph's GUI - GraphStudio and Admin Portal.
-The application server follows the active-active architecture, and runs on the *first five nodes* in a cluster by default.
+The application server follows the active-active architecture, and runs on the *first three nodes* in a cluster by default.
 
 NOTE: _**Three ** is the maximum number of application servers per cluster.
 If one server falls offline, you can use the other servers without any loss of functionality._

--- a/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
+++ b/modules/cluster-and-ha-management/pages/ha-for-application-server.adoc
@@ -4,10 +4,12 @@
 
 TigerGraph supports native HA functionality for its application server, which serves the APIs for TigerGraph's GUI - GraphStudio and Admin Portal.
 The application server follows the active-active architecture, and runs on the *first five nodes* in a cluster by default.
-Five is the maximum number of application servers per cluster.
-If one server falls offline, you can use the other servers without any loss of functionality.
+
+NOTE: _**Three ** is the maximum number of application servers per cluster.
+If one server falls offline, you can use the other servers without any loss of functionality._
 
 When you deploy TigerGraph in a cluster with multiple replicas, it is ideal to set up load balancing to distribute network traffic evenly across the different servers.
+
 This page discusses what to do when a server fails when you haven't set up load balancing, and the steps needed to set up load balancing for the application server.
 
 


### PR DESCRIPTION
Associated task: https://graphsql.atlassian.net/browse/DOC-1862

Correction in docs for 5 max clusters to 3 max clusters. Plus style changes for clarity. To be merged in 3.9LTS, 3.8, 3.7, 3.6LTS.


<img width="730" alt="Screen Shot 2023-09-22 at 10 57 42 AM" src="https://github.com/tigergraph/server-docs/assets/144745015/c7462b4a-ffab-468d-bc48-d3fee4fdaf00">

