### PR TITLE
Update enabling-user-authentication.adoc

### DIFF
--- a/modules/user-access/pages/enabling-user-authentication.adoc
+++ b/modules/user-access/pages/enabling-user-authentication.adoc
@@ -51,7 +51,7 @@ To enable RESTPP authentication, set the `RESTPP.Factory.EnableAuth` parameter t
 
 . As the TigerGraph Linux user, run the following command:
 +
-.Enabling REST{pp} OAuth Authentication
+.Enabling REST{pp} SAML2.0 Authentication
 +
 [source,bash]
 ----
@@ -62,7 +62,7 @@ $ gadmin config set RESTPP.Factory.EnableAuth true
 
 . Run the following commands to save the configuration and restart system services:
 +
-.Enabling REST{pp} OAuth Authentication
+.Enabling REST{pp} SAML2.0 Authentication
 +
 [source,bash]
 ----


### PR DESCRIPTION
OAuth to SAML2.0 change for 3.5...

it looks like version 3.6 and below require a pull request.

<img width="526" alt="Screen Shot 2023-09-20 at 5 44 57 PM" src="https://github.com/tigergraph/server-docs/assets/144745015/091f953e-3669-46e5-a3fe-c635909dff0c">


