### PR TITLE
DOC-1829-AddingCompression Level And Process Number to 8

### DIFF
--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -47,8 +47,8 @@ Typically used when operating in a private network or with a non-AWS S3-compatib
 
 |System.Backup.CompressProcessNumber | Number of concurrent processes for compression during backup.
 
-It's recommended to keep the default value `8`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
-| `8`
+It's recommended to keep the default value `10`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
+| `10`
 
 |System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.
 | `8`

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -55,7 +55,7 @@ It's recommended to keep the default value `0`, which means the number of proces
 
 |System.Backup.CompressionLevel |The backup compression level strikes a balance between size and speed. The better compression, the longer it takes.
 ("BestSpeed", "DefaultCompression", "BestCompression")
-| `DefaultCompression`
+| "DefaultCompression"
 |===
 
 IMPORTANT: If `System.Backup.Local.Enable` is set to `true`, this also enables a daily full backup at 12:00am UTC.

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -47,7 +47,7 @@ Typically used when operating in a private network or with a non-AWS S3-compatib
 
 |System.Backup.CompressProcessNumber | Number of concurrent processes for compression during backup.
 
-It's recommended to keep the default value `0`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
+It's recommended to keep the default value `8`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
 | `8`
 
 |System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -50,6 +50,9 @@ Typically used when operating in a private network or with a non-AWS S3-compatib
 It's recommended to keep the default value `0`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
 | `8`
 
+|System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.
+| `8`
+
 |System.Backup.CompressionLevel |The backup compression level strikes a balance between size and speed. The better compression, the longer it takes.
 ("BestSpeed", "DefaultCompression", "BestCompression")
 | `DefaultCompression`

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -48,7 +48,11 @@ Typically used when operating in a private network or with a non-AWS S3-compatib
 |System.Backup.CompressProcessNumber | Number of concurrent processes for compression during backup.
 
 It's recommended to keep the default value `0`, which means the number of processes used to compress is equal to the number of CPU cores on each node.
-| `0`
+| `8`
+
+|System.Backup.CompressionLevel |The backup compression level strikes a balance between size and speed. The better compression, the longer it takes.
+("BestSpeed", "DefaultCompression", "BestCompression")
+| `DefaultCompression`
 |===
 
 IMPORTANT: If `System.Backup.Local.Enable` is set to `true`, this also enables a daily full backup at 12:00am UTC.

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1155,7 +1155,7 @@ empty. You can use @/cert/file/path to pass the certificate from a file.
 |`Va2V7mdpTY5ErZRmTBBRqYtkgR7CiGbF`
 
 |System.Backup.CompressProcessNumber |The number of concurrent process
-for compression during backup. Value 0 means the number of processes
+for compression during backup. Value 8 means the number of processes
 used to compress equals the node CPU’s cores. |`8`
 
 |System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1156,7 +1156,14 @@ empty. You can use @/cert/file/path to pass the certificate from a file.
 
 |System.Backup.CompressProcessNumber |The number of concurrent process
 for compression during backup. Value 0 means the number of processes
-used to compress equals the node CPU’s cores. |`0`
+used to compress equals the node CPU’s cores. |`8`
+
+|System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.
+| `8`
+
+|System.Backup.CompressionLevel |The backup compression level strikes a balance between size and speed. The better compression, the longer it takes.
+("BestSpeed", "DefaultCompression", "BestCompression")
+| "DefaultCompression"
 
 |System.Backup.Local.Enable |Backup data to local path *IMPORTANT*: If set to `true`, this also enables a daily full backup at 12:00am UTC. |`false`
 

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1155,8 +1155,8 @@ empty. You can use @/cert/file/path to pass the certificate from a file.
 |`Va2V7mdpTY5ErZRmTBBRqYtkgR7CiGbF`
 
 |System.Backup.CompressProcessNumber |The number of concurrent process
-for compression during backup. Value 8 means the number of processes
-used to compress equals the node CPU’s cores. |`8`
+for compression during backup. Value `10` means the number of processes
+used to compress equals the node CPU’s cores. |`10`
 
 |System.Backup.DecompressProcessNumber | The number of concurrent processes for decompression during the restore.
 | `8`


### PR DESCRIPTION
Addition/Update for 3.9.3
Attached to this task: https://graphsql.atlassian.net/browse/DOC-1829 

Changes in this pull request
- Added to table System.Backup.CompressionLevel, description, and default value
- Added to table System.Backup.DecompressProcessNumber, description, and default value
- Change default value of System.Backup.CompressProcessNumber from 0 to 10

Link to current tables in the documentation: 

1. https://docs.tigergraph.com/tigergraph-server/current/backup-and-restore/configurations#_configuration_parameters 
3. https://docs.tigergraph.com/tigergraph-server/current/reference/configuration-parameters#_system  


