### PR TITLE
Updated k8s Doc with GitHub link and updated command

### DIFF
--- a/modules/kubernetes/pages/k8s-operator/index.adoc
+++ b/modules/kubernetes/pages/k8s-operator/index.adoc
@@ -1,9 +1,8 @@
 = Kubernetes Operator
 :description: Introduction to TigerGraph Kubernetes Operator.
 
-IMPORTANT: The internal documents of the Kubernetes Operator are frequently updated detailing specific use case
-operational and troubleshooting steps. We have provided a public GitHub repo (https://github.com/tigergraph/ecosys/tree/master/k8s) to share all relevant knowledge
-more easily and readily help deploy and mange TigerGraph clusters on Kubernetes.
+IMPORTANT: The internal documents of the Kubernetes Operator are frequently updated detailing specific use case operational and troubleshooting steps.
+We have provided a public GitHub repo (https://github.com/tigergraph/ecosys/tree/master/k8s) to share all relevant knowledge more easily and readily help deploy and mange TigerGraph clusters on Kubernetes.
 
 The TigerGraph Kubernetes Operator provides native integration of TigerGraph Server with Kubernetes.
 It enables you to automate operations such as the creation, status checking, resizing and deletion of TigerGraph clusters.

--- a/modules/kubernetes/pages/k8s-operator/index.adoc
+++ b/modules/kubernetes/pages/k8s-operator/index.adoc
@@ -1,6 +1,10 @@
 = Kubernetes Operator
 :description: Introduction to TigerGraph Kubernetes Operator.
 
+IMPORTANT: The internal documents of the Kubernetes Operator are frequently updated detailing specific use case
+operational and troubleshooting steps. We have provided a public GitHub repo (https://github.com/tigergraph/ecosys/tree/master/k8s) to share all relevant knowledge
+more easily and readily help deploy and mange TigerGraph clusters on Kubernetes.
+
 The TigerGraph Kubernetes Operator provides native integration of TigerGraph Server with Kubernetes.
 It enables you to automate operations such as the creation, status checking, resizing and deletion of TigerGraph clusters.
 

--- a/modules/kubernetes/pages/k8s-operator/index.adoc
+++ b/modules/kubernetes/pages/k8s-operator/index.adoc
@@ -1,11 +1,7 @@
 = Kubernetes Operator
 :description: Introduction to TigerGraph Kubernetes Operator.
 
-IMPORTANT: The internal documents of the Kubernetes Operator are frequently updated detailing specific use case operational and troubleshooting steps.
-We have provided a public GitHub repo (https://github.com/tigergraph/ecosys/tree/master/k8s) to share all relevant knowledge more easily and readily help deploy and mange TigerGraph clusters on Kubernetes.
-
-The TigerGraph Kubernetes Operator provides native integration of TigerGraph Server with Kubernetes.
-It enables you to automate operations such as the creation, status checking, resizing and deletion of TigerGraph clusters.
+IMPORTANT: To readily help users deploy and manage TigerGraph clusters on Kubernetes, we have provided a public GitHub repo (https://github.com/tigergraph/ecosys/tree/master/k8s) to our internal documentation of the Kubernetes Operator. These docs are frequently updated to support operational, troubleshooting, and all other relevant use cases.
 
 By reducing the complexity of running a TigerGraph cluster, it lets you focus on the desired state of your clusters and saves you time from the details of manual deployment and life-cycle management.
 

--- a/modules/kubernetes/pages/k8s-operator/installation.adoc
+++ b/modules/kubernetes/pages/k8s-operator/installation.adoc
@@ -27,7 +27,7 @@ Run the command below to install the TigerGraph plugin for the `kubectl` command
 
 [.wrap,console]
 ----
-curl https://dl.tigergraph.com/k8s/0.0.4/kubectl-tg  -o kubectl-tg
+curl https://dl.tigergraph.com/k8s/latest/kubectl-tg  -o kubectl-tg
 sudo install kubectl-tg /usr/local/bin/
 ----
 


### PR DESCRIPTION
Associated task(s): https://graphsql.atlassian.net/browse/DOC-1846

-Added an "Important" aside to top of documentation explaining and linking the internal public GitHub repo
--Link to current page : https://docs.tigergraph.com/tigergraph-server/current/kubernetes/k8s-operator/

-Update the specific kubectl-tg plugin version command line to the latest version as requested in the ticket 
-- Link to current page : https://docs.tigergraph.com/tigergraph-server/current/kubernetes/k8s-operator/installation

Ex. of command line change:
curl https://dl.tigergraph.com/k8s/0.0.4/kubectl-tg  -o kubectl-tg
sudo install kubectl-tg /usr/local/bin/
to
curl https://dl.tigergraph.com/k8s/latest/kubectl-tg  -o kubectl-tg
sudo install kubectl-tg /usr/local/bin/