### PR TITLE
Removing both SAML2.0 and OAuth

### DIFF
--- a/modules/user-access/pages/enabling-user-authentication.adoc
+++ b/modules/user-access/pages/enabling-user-authentication.adoc
@@ -56,7 +56,7 @@ To enable RESTPP authentication, set the `RESTPP.Factory.EnableAuth` parameter t
 
 . As the TigerGraph Linux user, run the following command:
 +
-.Enabling REST{pp} SAML2.0 Authentication
+.Enabling REST{pp} Authentication
 +
 [source,bash]
 ----
@@ -67,7 +67,7 @@ $ gadmin config set RESTPP.Factory.EnableAuth true
 
 . Run the following commands to save the configuration and restart system services:
 +
-.Enabling REST{pp} SAML2.0 Authentication
+.Enabling REST{pp} Authentication
 +
 [source,bash]
 ----


### PR DESCRIPTION
Associated Jira Task: https://graphsql.atlassian.net/browse/DOC-1855 

Based on discussion and clarification, this pull request removes misleading SAML2.0 and OAuth words in the documentation.

<img width="855" alt="Screen Shot 2023-09-27 at 9 59 25 AM" src="https://github.com/tigergraph/server-docs/assets/144745015/6f61adfe-bd9b-4ec0-afd5-8b90733e9702">
