### PR TITLE
CrossClusterRedo393

### DIFF
--- a/modules/backup-and-restore/pages/cross-cluster-backup.adoc
+++ b/modules/backup-and-restore/pages/cross-cluster-backup.adoc
@@ -11,20 +11,8 @@ Your cluster is offline during the restore process.
 * TigerGraph is installed on the new cluster in the exact same version as the previous cluster.
 * You have access to the TigerGraph Linux user account on your cluster.
 All commands must be run from the TigerGraph Linux user.
-* You have access to a data backup from another cluster.
+* You have access to a data backup from another cluster, and *for versions 3.9.1 and below*, its metadata backup.
 * You have xref:configurations.adoc[configured backup and restore] on the new cluster.
-
-NOTE: Since v3.9.2, it is no longer required to create a backup for a backups metadata or upload the metadata to a new cluster.
-A backup’s metadata is now stored as a part of a backup's files, but the previous method is still supported. *See xref:_prerequisites_v3_9_1_and_below[].
-
-Simply run:
-
-[source,console,]
---
-gadmin backup restore <backup_tag>
---
-
-Just like restoring a backup in its original cluster.
 
 == Copy data backup to new cluster
 
@@ -49,16 +37,6 @@ They do not necessarily need to be on the corresponding nodes as long as all par
 
 For example, if you have configured the backup path to be `/home/tigergraph/backups` for a 3-node cluster, you can put all backup files for backup `weekly-<timestamp>` in the folder `/home/tigergraph/backups/weekly-<timestamp>`.
 
-IMPORTANT: For all previous versions please follow the steps below.
-
-== Prerequisites v3.9.1 and below
-* Your new cluster has the same xref:cluster-and-ha-management:ha-cluster.adoc[partitioning factor] as the cluster from which the backup file was created.
-* TigerGraph is installed on the new cluster in the exact same version as the previous cluster.
-* You have access to the TigerGraph Linux user account on your cluster.
-All commands must be run from the TigerGraph Linux user.
-* You have access to a data backup from another cluster as well as its xref:backup-cluster.adoc#_metadata_backup_optional[metadata backup].
-* You have xref:configurations.adoc[configured backup and restore] on the new cluster.
-
 == Procedure
 
 === 1) Upload metadata to new cluster
@@ -77,6 +55,15 @@ They do not necessarily need to be on the corresponding nodes as long as all par
 For example, if you have configured the backup path to be `/home/tigergraph/backups` for a 3-node cluster, you can put all backup files for backup `weekly-<timestamp>` in the folder `/home/tigergraph/backups/weekly-<timestamp>`.
 
 === 3) Restore cluster
+
+then run:
+
+[source,console,]
+--
+gadmin backup restore <backup_tag>
+--
+
+Just like restoring a backup in its original cluster.
 
 Run the following command to restore the cluster using the backup.
 You must run the command on the cluster to which you uploaded the cluster metadata:

--- a/modules/backup-and-restore/pages/cross-cluster-backup.adoc
+++ b/modules/backup-and-restore/pages/cross-cluster-backup.adoc
@@ -11,66 +11,97 @@ Your cluster is offline during the restore process.
 * TigerGraph is installed on the new cluster in the exact same version as the previous cluster.
 * You have access to the TigerGraph Linux user account on your cluster.
 All commands must be run from the TigerGraph Linux user.
-* You have access to a data backup from another cluster, and *for versions 3.9.1 and below*, its metadata backup.
+* You have access to a data backup from another cluster.
+* [xref:_procedure_v3_9_1_and_below[3.9.1 and earlier]] You have the metadata backup that goes with the data backup.
 * You have xref:configurations.adoc[configured backup and restore] on the new cluster.
-
-== Copy data backup to new cluster
-
-For an Amazon S3 backup, the restore flow will try to find a S3 object:
-
-[source, console]
---
-<backup_tag>_metadata
---
-
-From the Bucket `System.Backup.S3.BucketName`.
-
-If your backups were stored locally, you need to make sure backup files from all nodes are copied to the new cluster.
-The restore flow will try to find a metadata file under the backup path:
-
-[source,console]
---
-/path/to/{System.Backup.Local.Path}/<backup_tag>/metadata
---
-
-They do not necessarily need to be on the corresponding nodes as long as all partitions are in the new cluster at the specified paths you configured.
-
-For example, if you have configured the backup path to be `/home/tigergraph/backups` for a 3-node cluster, you can put all backup files for backup `weekly-<timestamp>` in the folder `/home/tigergraph/backups/weekly-<timestamp>`.
 
 == Procedure
 
-=== 1) Upload metadata to new cluster
-Upload the metadata file specific to the backup with which you want to restore the cluster to a path on any node of the new cluster where the TigerGraph Linux user has access.
+=== 1) Copy Data Backup to a New Cluster
 
-For example, upload the file to `/home/tigergraph/metadata` on m1 of the new cluster.
+==== For Amazon S3 Backup:
 
+If your backups are stored in Amazon S3 buckets, you can skip this step as long as you configure:
+[source,console]
+System.Backup.S3.BucketName
 
-=== 2) Copy data backup to new cluster
+For the new cluster to be the same as the previous cluster
 
-If your backups are stored in Amazon S3 buckets, you can skip this step as long as you configure `System.Backup.S3.BucketName` for the new cluster to be the same as the previous cluster.
+==== For Local Backup Storage:
 
 If your backups were stored locally, you need to make sure backup files from all nodes are copied to the new cluster.
 They do not necessarily need to be on the corresponding nodes as long as all partitions are in the new cluster at the specified paths you configured.
 
-For example, if you have configured the backup path to be `/home/tigergraph/backups` for a 3-node cluster, you can put all backup files for backup `weekly-<timestamp>` in the folder `/home/tigergraph/backups/weekly-<timestamp>`.
+* For example:
++
+.if you have configured the backup path to be:
+[source,console]
+/home/tigergraph/backups
++
+.For a 3-node cluster, you can put all backup files for backup:
+[source,console]
+weekly-<timestamp>
++
+.In the folder like this:
+[source,console]
+/home/tigergraph/backups/weekly-<timestamp>
 
-=== 3) Restore cluster
+=== 2) Restore Cluster
 
-then run:
-
-[source,console,]
---
+Now, just like restoring a backup in its original cluster. Simply run:
+[source, console]
 gadmin backup restore <backup_tag>
---
 
-Just like restoring a backup in its original cluster.
+== Procedure v3.9.1 and below
+
+=== 1) Upload Metadata to New Cluster
+Upload the metadata file specific to the backup with which you want to restore the cluster to a path on any node of the new cluster where the TigerGraph Linux user has access.
+
+For example, upload the  file to:
+[source, console]
+/home/tigergraph/metadata
+
+On m1 of the new cluster.
+
+
+=== 2) Copy Data Backup to a New Cluster
+
+==== For Amazon S3 Backup:
+
+If your backups are stored in Amazon S3 buckets, you can skip this step as long as you configure:
+[source,console]
+System.Backup.S3.BucketName
+
+For the new cluster to be the same as the previous cluster
+
+==== For Local Backup Storage:
+
+If your backups were stored locally, you need to make sure backup files from all nodes are copied to the new cluster.
+They do not necessarily need to be on the corresponding nodes as long as all partitions are in the new cluster at the specified paths you configured.
+
+* For example:
++
+.if you have configured the backup path to be:
+[source,console]
+/home/tigergraph/backups
++
+.For a 3-node cluster, you can put all backup files for backup:
+[source,console]
+weekly-<timestamp>
++
+.In the folder like this:
+[source,console]
+/home/tigergraph/backups/weekly-<timestamp>
+
+=== 3) Restore Cluster
 
 Run the following command to restore the cluster using the backup.
-You must run the command on the cluster to which you uploaded the cluster metadata:
+
+[IMPORTANT]
+You must run the command on the cluster to which you uploaded the cluster metadata.
 
 [.wrap,console]
 ----
 $ gadmin backup restore --meta=/home/tigergraph/metadata <1>
 ----
 <1> If you uploaded the metadata to a different folder, replace the path with the path where the file is.
-

--- a/modules/backup-and-restore/pages/cross-cluster-backup.adoc
+++ b/modules/backup-and-restore/pages/cross-cluster-backup.adoc
@@ -26,7 +26,7 @@ If your backups are stored in Amazon S3 buckets, set the following configuration
 [source,console]
 System.Backup.S3.BucketName
 
-for the new cluster to be the same as the previous cluster
+For the new cluster to be the same as the previous cluster
 
 ==== For Local Backup Storage:
 

--- a/modules/backup-and-restore/pages/cross-cluster-backup.adoc
+++ b/modules/backup-and-restore/pages/cross-cluster-backup.adoc
@@ -26,7 +26,7 @@ If your backups are stored in Amazon S3 buckets, set the following configuration
 [source,console]
 System.Backup.S3.BucketName
 
-For the new cluster to be the same as the previous cluster
+For the new cluster to be the same as the previous cluster.
 
 ==== For Local Backup Storage:
 
@@ -49,7 +49,7 @@ weekly-<timestamp>
 
 === 2) Restore Cluster
 
-Now, just like restoring a backup in its original cluster. Simply run:
+Now, just like restoring a backup in its original cluster, simply run:
 [source, console]
 gadmin backup restore <backup_tag>
 
@@ -73,7 +73,7 @@ If your backups are stored in Amazon S3 buckets, set the following configuration
 [source,console]
 System.Backup.S3.BucketName
 
-For the new cluster to be the same as the previous cluster
+For the new cluster to be the same as the previous cluster.
 
 ==== For Local Backup Storage:
 

--- a/modules/backup-and-restore/pages/cross-cluster-backup.adoc
+++ b/modules/backup-and-restore/pages/cross-cluster-backup.adoc
@@ -21,11 +21,12 @@ All commands must be run from the TigerGraph Linux user.
 
 ==== For Amazon S3 Backup:
 
-If your backups are stored in Amazon S3 buckets, you can skip this step as long as you configure:
+If your backups are stored in Amazon S3 buckets, set the following configuration parameter to be the location of your backup files.
+
 [source,console]
 System.Backup.S3.BucketName
 
-For the new cluster to be the same as the previous cluster
+for the new cluster to be the same as the previous cluster
 
 ==== For Local Backup Storage:
 
@@ -34,15 +35,15 @@ They do not necessarily need to be on the corresponding nodes as long as all par
 
 * For example:
 +
-.if you have configured the backup path to be:
+.If you have configured the backup path to be
 [source,console]
 /home/tigergraph/backups
 +
-.For a 3-node cluster, you can put all backup files for backup:
+.for a 3-node cluster, you can put all backup files for backup
 [source,console]
 weekly-<timestamp>
 +
-.In the folder like this:
+.in the folder like this:
 [source,console]
 /home/tigergraph/backups/weekly-<timestamp>
 
@@ -57,18 +58,18 @@ gadmin backup restore <backup_tag>
 === 1) Upload Metadata to New Cluster
 Upload the metadata file specific to the backup with which you want to restore the cluster to a path on any node of the new cluster where the TigerGraph Linux user has access.
 
-For example, upload the  file to:
+For example, upload the  file to
 [source, console]
 /home/tigergraph/metadata
 
-On m1 of the new cluster.
-
+on m1 of the new cluster.
 
 === 2) Copy Data Backup to a New Cluster
 
 ==== For Amazon S3 Backup:
 
-If your backups are stored in Amazon S3 buckets, you can skip this step as long as you configure:
+If your backups are stored in Amazon S3 buckets, set the following configuration parameter to be the location of your backup files.
+
 [source,console]
 System.Backup.S3.BucketName
 
@@ -81,15 +82,15 @@ They do not necessarily need to be on the corresponding nodes as long as all par
 
 * For example:
 +
-.if you have configured the backup path to be:
+.If you have configured the backup path to be
 [source,console]
 /home/tigergraph/backups
 +
-.For a 3-node cluster, you can put all backup files for backup:
+.for a 3-node cluster, you can put all backup files for backup
 [source,console]
 weekly-<timestamp>
 +
-.In the folder like this:
+.in the folder like this:
 [source,console]
 /home/tigergraph/backups/weekly-<timestamp>
 


### PR DESCRIPTION
Associated task: https://graphsql.atlassian.net/browse/DOC-1830
Redo to cross cluster restore updates based on review.

Addressing these notes from closed PR:

- Organization: The two Prerequisites sections are almost identical. I would be inclined to only list them once at the beginning, and have one bullet point: [3.9.1 and earlier] You have the metadata backup that goes with the data backup.
**I have adjusted the organization and reduced it to one prerequisites section**

- Organization: The 3.9.2+ steps are not in the right order. You have gadmin backup restore first and then Copy data backup to new cluster.
****I have adjusted the organization to be in the correct order****

- The two sections (pre-3.9.2, post-3.9.2) have different heading levels.
**Adjusted header levels**

- The two sections (pre-3.9.2, post-3.9.2) have different wording and level of details for S3 , but they don't actually conflict. Do the two product versions have the same actual S3 behavior? If so, use the same (best) wording. If they have different behavior, then spell it out more clearly.
-- For both S3 and local backups, it is incomplete to say "the restore flow will try to find the metadata at...". The problem is "try".
--(a) What if it doesn't find it there? Then what?
-- (b) I'm guessed that a 3.9.2+ backup operation puts the metadata file at
-- <backup_folder>/metadata. Please check with the developer.
-- (c) If that's true, then what the developer was saying is that the restore operation looks for the metadata in the place that the backup operation put it. Duh.
-- (Either explain this is full as an FYI, or don't explain it at all, because the intent is that TG handles this for you so that the users doesn't need to worry about the metadata.)
-- (d) The whole point of the "Copy data backup to new cluster" section is that
-- i. There are configuration parameters for the new cluster to specify where to write/read backup files. Set those parameters.
-- ii. Put the backup files there.
-- Put currently, this section does not say that in a straightforward way.
-- I'm pretty sure that there are no differences for the non-metadata part of backup/restore, so that the whole "Copy data backup to new cluster" can/should read the same for both versions.

**To answer the next grouping of questions all at once. Yes I do believe they have the same "Copy data to New Cluster"**

**The developer said:**
**...for local backup, the backup path should be where the backups to restore are, for s3, the bucket should be where the** **backups to restore are...**

**So, I reverted it to the old wording. I did change the format of each section to help the users eyes as they read the document.**
