### PR TITLE
Update cluster-operations.adoc

### DIFF
--- a/modules/kubernetes/pages/k8s-operator/cluster-operations.adoc
+++ b/modules/kubernetes/pages/k8s-operator/cluster-operations.adoc
@@ -42,7 +42,6 @@ The command does not create a namespace for you.
 You can specify pod CPU, memory, TigerGraph version, and other parameters through command-line options.
 
 You must also provide your license key with the `--license` command. Contact TigerGraph support for help finding your license key.
-A free license, valid for 14 days, is available through this link: A free license is available through this link: ftp://ftp.graphtiger.com/lic/license3.txt
 
 Starting with Operator version 0.0.4, you need to provide your own SSH key for security. See link:https://kubernetes.io/docs/concepts/configuration/secret/[Secrets in Kubernetes] for more information.
 In this example, it is named `ssh-key-secret`.


### PR DESCRIPTION
Associated task: https://graphsql.atlassian.net/browse/DOC-1893

- removing the line: "A free license, valid for 14 days, is available through this link: A free license is available through this link: ftp://ftp.graphtiger.com/lic/license3.txt"