### PR TITLE
3.6_removing Avro from Kafka loader supported files

### DIFF
--- a/modules/data-loading/pages/kafka-loader/index.adoc
+++ b/modules/data-loading/pages/kafka-loader/index.adoc
@@ -31,6 +31,7 @@ A resumed job picks up from where it was stopped before and will not consume mes
 == Supported file formats
 * CSV
 * JSON
+* Avro (when sourced from an xref:tigergraph-server:data-loading:data-streaming-connector.adoc#_stream_data_from_an_external_kafka_cluster[external Kafka cluster])
 
 [CAUTION]
 .NULL is not a valid input valid.

--- a/modules/data-loading/pages/kafka-loader/index.adoc
+++ b/modules/data-loading/pages/kafka-loader/index.adoc
@@ -29,7 +29,6 @@ A resumed job picks up from where it was stopped before and will not consume mes
 ====
 
 == Supported file formats
-* Avro
 * CSV
 * JSON
 


### PR DESCRIPTION
Associated task: https://graphsql.atlassian.net/browse/DOC-1899

- removing Avro from Kafka loader supported files 3.6