### PR TITLE
DOC-1903 add missing RESTPP return code 3.9.3

### DIFF
--- a/modules/API/nav.adoc
+++ b/modules/API/nav.adoc
@@ -2,3 +2,4 @@
 ** xref:authentication.adoc[]
 ** xref:built-in-endpoints.adoc[]
 ** xref:json-catalog.adoc[]
+** xref:upsert-rest.adoc[]

--- a/modules/reference/pages/return-codes.adoc
+++ b/modules/reference/pages/return-codes.adoc
@@ -127,10 +127,10 @@ Other RESTPP errors.
 | The payload is invalid (general error).
 
 | `REST-30200`
-| The parameter for link:https://docs.tigergraph.com/tigergraph-server/current/api/upsert-rest[upserting data] is invalid.
+| The parameter for xref:tigergraph-server:API:upsert-rest.adoc[upserting data] is invalid.
 
 | `REST-30400`
-| The parameter for link:https://docs.tigergraph.com/tigergraph-server/current/api/built-in-endpoints#_show_query_performance[showing query performance] is invalid.
+| The parameter for xref:tigergraph-server:API:built-in-endpoints.adoc#_show_query_performance[showing query performance] is invalid.
 |===
 
 === GSQL

--- a/modules/reference/pages/return-codes.adoc
+++ b/modules/reference/pages/return-codes.adoc
@@ -122,6 +122,15 @@ Other RESTPP errors.
 
 | `REST-12003`
 | The query failed due to insufficient disk space.
+
+| `REST-30000`
+| The payload is invalid (general error).
+
+| `REST-30200`
+| The parameter for link:https://docs.tigergraph.com/tigergraph-server/current/api/upsert-rest[upserting data] is invalid.
+
+| `REST-30400`
+| The parameter for link:https://docs.tigergraph.com/tigergraph-server/current/api/built-in-endpoints#_show_query_performance[showing query performance] is invalid.
 |===
 
 === GSQL


### PR DESCRIPTION
Add missing RESTPP return codes as described in [DOC-1903](https://graphsql.atlassian.net/browse/DOC-1903)

[DOC-1903]: https://graphsql.atlassian.net/browse/DOC-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ