### PR TITLE
Update docker.adoc

### DIFF
--- a/modules/getting-started/pages/docker.adoc
+++ b/modules/getting-started/pages/docker.adoc
@@ -71,7 +71,7 @@ $ docker run -d \ <1>
     --name tigergraph \ <3>
     --ulimit nofile=1000000:1000000 \ <4>
     -v ~/data:/home/tigergraph/mydata \ <5>
-    -v tg-data:/home/tigergraph <6> \
+    -v tg-data:/home/tigergraph \ <6>
     -t \ <7>
     tigergraph/tigergraph:latest <8>
 ----


### PR DESCRIPTION
Docker installation commands do not work because of improper formatting. Formatting has been fixed in this change so the commands from the docs can be copy+pasted and run.

https://docs.tigergraph.com/tigergraph-server/current/getting-started/docker#_run_the_tigergraph_docker_image_as_a_daemon