### PR TITLE
remove license information 3.9 and above

### DIFF
--- a/modules/installation/pages/license.adoc
+++ b/modules/installation/pages/license.adoc
@@ -66,31 +66,7 @@ If the installation completes successfully, the message "install license success
 
 === Checking License Information
 
-After a license key has been installed successfully on a TigerGraph system, the information of the installed license is available via either the CLI command `gadmin license status` or via the following REST API:
-
-.Get License Information
-
-[source,console]
-----
- $ curl -X GET "localhost:9000/showlicenseinfo"
-  {
-    "message": "",
-    "error": false,
-    "version": {
-      "edition": "developer",
-      "schema": 0,
-      "api": "v2",
-    }
-    "code": "",
-    "results": [
-      {
-        "Days remaining": 10160,
-        "Expiration date": "Mon Oct  2 04:00:00 2045\n"
-      }
-    ]
-  }
-----
-
+After a license key has been installed successfully on a TigerGraph system, the information of the installed license is available via the CLI command `gadmin license status`.
 
 
 == Usage Limits Controlled by License Key


### PR DESCRIPTION
associated ticket: https://graphsql.atlassian.net/browse/DOC-1963

Improvement: Removed  `curl -X GET "localhost:9000/showlicenseinfo"` from documentation

