### PR TITLE
DOC-2111 docs(license): add the filepath method for setting TG license;

### DIFF
--- a/modules/installation/pages/license.adoc
+++ b/modules/installation/pages/license.adoc
@@ -44,14 +44,25 @@ $ gadmin license seed hardware
  .. Contract number. If you do not know your contract number, please contact your sales representative or link:mailto:sales@tigergraph.com.[sales@tigergraph.com.]
 . A new license key file will be certificated and sent back to you.
 . Copy the license key file to a directory on the TigerGraph system where the TigerGraph Linux user has read permission.
-. Run the following three commands to install the license key:
+. Run the following command to install the license key:
 +
 [source,text]
 ----
 $ gadmin license set <new_license_key>
 [   Info] Configuration has been changed.
 Please use 'gadmin config apply' to persist the changes.
+----
+Alternatively, you may save the license key in a file, and set the license key with the filepath syntax:
++
+----
+$ gadmin license set @<path_to_license_file>
+[   Info] Configuration has been changed.
+Please use 'gadmin config apply' to persist the changes.
+----
 
+. Finally, run the following commands to apply the license key and restart services:
++
+----
 $ gadmin config apply
 [Warning] No difference from staging config, config apply is skipped.
 [   Info] Successfully applied configuration change. Please restart services to make it effective immediately.

--- a/modules/installation/pages/license.adoc
+++ b/modules/installation/pages/license.adoc
@@ -43,7 +43,6 @@ $ gadmin license seed hardware
  .. Company/Organization name
  .. Contract number. If you do not know your contract number, please contact your sales representative or link:mailto:sales@tigergraph.com.[sales@tigergraph.com.]
 . A new license key file will be certificated and sent back to you.
-. Copy the license key file to a directory on the TigerGraph system where the TigerGraph Linux user has read permission.
 . Run the following command to install the license key:
 +
 [source,text]
@@ -52,7 +51,7 @@ $ gadmin license set <new_license_key>
 [   Info] Configuration has been changed.
 Please use 'gadmin config apply' to persist the changes.
 ----
-Alternatively, you may save the license key in a file, and set the license key with the filepath syntax:
+Alternatively, you may save the license key in a file where the TigerGraph Linux user has read permission, and set the license key with the filepath syntax:
 +
 ----
 $ gadmin license set @<path_to_license_file>


### PR DESCRIPTION
Doc ticket link: https://graphsql.atlassian.net/browse/DOC-2111
Before change:
<img width="1331" alt="Screenshot 2024-07-01 at 6 28 08 PM" src="https://github.com/tigergraph/server-docs/assets/110949159/3807dd92-6d4b-4769-b79d-a9e01b292640">

After change:
<img width="1141" alt="Screenshot 2024-07-08 at 6 42 39 PM" src="https://github.com/tigergraph/server-docs/assets/110949159/b86a0fbd-a569-4d29-b1f8-5d7688370d74">

