### PR TITLE
DOC-2197 docs(backup): add s3 backup roleARN config to backup doc;

### DIFF
--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -32,6 +32,11 @@ Required if backup is to be stored on S3.
 *NOTE*: If setting this in interactive mode, store the key in a file and provide the path to the file, e.g., `@/tmp/test_secret`.
 |`+nan+`
 
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combo of access key id and secret access key in accessing s3. Note this is only for AWS S3, and that using role ARN assumes access key id and secret access key are already configured with AWS CLI
+
+*NOTE*: This is only for AWS S3, and that using role ARN assumes access key id, secret access key and region are already configured with AWS CLI `aws configure`.
+|`+nan+`
+
 |System.Backup.S3.BucketName |Name of the S3 bucket to store backup files.
 Required if backup is to be stored on S3.|null
 
@@ -139,6 +144,12 @@ gadmin config set "System.Backup.S3.AWSAccessKeyID" "<access-key-id>"
 [console,]
 ----
 gadmin config set "System.Backup.S3.AWSSecretAccessKey" "<secret-access-key>"
+----
++
+.Alternatively, instead of using `AccessKeyID` and `SecretAccessKey`, you may use AWS Role ARN for the authentication
+[console,]
+----
+gadmin config set "System.Backup.S3.RoleARN" "<aws-role-arn>"
 ----
 +
 .Apply the new parameter values

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -32,9 +32,9 @@ Required if backup is to be stored on S3.
 *NOTE*: If setting this in interactive mode, store the key in a file and provide the path to the file, e.g., `@/tmp/test_secret`.
 |`+nan+`
 
-|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combo of access key id and secret access key in accessing s3. Note this is only for AWS S3, and that using role ARN assumes access key id and secret access key are already configured with AWS CLI
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3.
 
-*NOTE*: This is only for AWS S3, and that using role ARN assumes access key id, secret access key and region are already configured with AWS CLI `aws configure`.
+*NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.
 |`+nan+`
 
 |System.Backup.S3.BucketName |Name of the S3 bucket to store backup files.

--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -32,7 +32,7 @@ Required if backup is to be stored on S3.
 *NOTE*: If setting this in interactive mode, store the key in a file and provide the path to the file, e.g., `@/tmp/test_secret`.
 |`+nan+`
 
-|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3.
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3. To understand what AWS role ARN is, see link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html[AWS role ARN doc].
 
 *NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.
 |`+nan+`
@@ -146,10 +146,10 @@ gadmin config set "System.Backup.S3.AWSAccessKeyID" "<access-key-id>"
 gadmin config set "System.Backup.S3.AWSSecretAccessKey" "<secret-access-key>"
 ----
 +
-.Alternatively, instead of using `AccessKeyID` and `SecretAccessKey`, you may use AWS Role ARN for the authentication
+.Alternatively, instead of using `AccessKeyID` and `SecretAccessKey`, you may use link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arnsp[AWS Role ARN] for the authentication
 [console,]
 ----
-gadmin config set "System.Backup.S3.RoleARN" "<aws-role-arn>"
+gadmin config set "System.Backup.S3.RoleARN" "arn:aws:iam::account:role/role-name-with-path"
 ----
 +
 .Apply the new parameter values

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1243,6 +1243,8 @@ backup |`nan`
 |System.Backup.S3.AWSSecretAccessKey |The secret access key for s3
 bucket |`nan`
 
+|System.Backup.S3.RoleARN |The AWS role for accessing S3 bucket, its use is prioritized over the combo of access key ID and secret access key in accessing S3. Note this is only for AWS S3, and that using role ARN assumes access key ID and secret access key are already configured with AWS CLI. |`nan`
+
 |System.Backup.S3.BucketName |The S3 bucket name |`nan`
 
 |System.Backup.S3.Enable |Backup data to S3 path |`false`

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1243,7 +1243,7 @@ backup |`nan`
 |System.Backup.S3.AWSSecretAccessKey |The secret access key for s3
 bucket |`nan`
 
-|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3.
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3. To understand what AWS role ARN is, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns[AWS role ARN doc].
 
 *NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.|`nan`
 

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1243,7 +1243,9 @@ backup |`nan`
 |System.Backup.S3.AWSSecretAccessKey |The secret access key for s3
 bucket |`nan`
 
-|System.Backup.S3.RoleARN |The AWS role for accessing S3 bucket, its use is prioritized over the combo of access key ID and secret access key in accessing S3. Note this is only for AWS S3, and that using role ARN assumes access key ID and secret access key are already configured with AWS CLI. |`nan`
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3.
+
+*NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.|`nan`
 
 |System.Backup.S3.BucketName |The S3 bucket name |`nan`
 


### PR DESCRIPTION
ticket link: https://graphsql.atlassian.net/browse/DOC-2197

In `configurations.adoc`:
<img width="935" alt="Screenshot 2024-08-26 at 6 35 39 PM" src="https://github.com/user-attachments/assets/c9cf614e-e2b2-4254-8a63-1b128986ec4d">

Added sections:
<img width="934" alt="Screenshot 2024-08-26 at 6 35 54 PM" src="https://github.com/user-attachments/assets/52d0f9ab-44a6-4f42-a27c-e49b29e160a4">

In `configuration-parameters.adoc`:
<img width="935" alt="Screenshot 2024-08-26 at 6 41 14 PM" src="https://github.com/user-attachments/assets/ab42a573-db1f-49dc-9bea-f4a7ca748518">
