### PR TITLE
DOC-2301 docs(backup): add s3 backup roleARN config (3.11)

### DIFF
--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -32,6 +32,11 @@ Required if backup is to be stored on S3.
 *NOTE*: If setting this in interactive mode, store the key in a file and provide the path to the file, e.g., `@/tmp/test_secret`.
 |`+nan+`
 
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3. To understand what AWS role ARN is, see link:https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html[AWS role ARN doc].
+
+*NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.
+|`+nan+`
+
 |System.Backup.S3.BucketName |Name of the S3 bucket to store backup files.
 Required if backup is to be stored on S3.|null
 
@@ -139,6 +144,12 @@ gadmin config set "System.Backup.S3.AWSAccessKeyID" "<access-key-id>"
 [console,]
 ----
 gadmin config set "System.Backup.S3.AWSSecretAccessKey" "<secret-access-key>"
+----
++
+.Alternatively, instead of using `AccessKeyID` and `SecretAccessKey`, you may use link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arnsp[AWS Role ARN] for the authentication
+[console,]
+----
+gadmin config set "System.Backup.S3.RoleARN" "arn:aws:iam::account:role/role-name-with-path"
 ----
 +
 .Apply the new parameter values

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1241,6 +1241,10 @@ backup |`nan`
 |System.Backup.S3.AWSSecretAccessKey |The secret access key for s3
 bucket |`nan`
 
+|System.Backup.S3.RoleARN |The AWS role for accessing s3 bucket, its use is prioritized over the combination of access key id and secret access key in accessing s3. To understand what AWS role ARN is, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns[AWS role ARN doc].
+
+*NOTE*: This is only for AWS S3, and TigerGraph assumes the credentials for using `sts:AssumeRole` have been set up. You can verify the credentials are ready by running link:https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples[aws sts assume-role]. One way to set up credentials is to configure access key id, secret access key and region with AWS CLI `aws configure`.|`nan`
+
 |System.Backup.S3.BucketName |The S3 bucket name |`nan`
 
 |System.Backup.S3.Enable |Backup data to S3 path |`false`


### PR DESCRIPTION
Ticket: https://graphsql.atlassian.net/browse/DOC-2301
This is a clone PR of DOC-2197, same change but for 3.11.0
original PR: https://github.com/tigergraph/server-docs/pull/453