### PR TITLE
DOC-2302 feat(metric): use new metric response from IFM RESTful API in openmetrics format; 

### DIFF
--- a/modules/API/pages/built-in-endpoints.adoc
+++ b/modules/API/pages/built-in-endpoints.adoc
@@ -452,65 +452,73 @@ Response::
 --
 [,text]
 ----
+# HELP tigergraph_cpu_available Percentage of available CPU capacity
+# TYPE tigergraph_cpu_available gauge
+tigergraph_cpu_available{host_id="m1",service_name=""} 98.2397232055664
+# HELP tigergraph_cpu_logical_cores_total Total number of logical CPU cores of a node
+# TYPE tigergraph_cpu_logical_cores_total gauge
+tigergraph_cpu_logical_cores_total{host_id="m1",service_name=""} 8
 # HELP tigergraph_cpu_usage Percentage of CPU usage by component. Service name empty means usage of the whole node
 # TYPE tigergraph_cpu_usage gauge
-tigergraph_cpu_usage{host_id="m1",service_name=""} 62.04006576538086
-tigergraph_cpu_usage{host_id="m1",service_name="ADMIN"} 0.4452745020389557
-tigergraph_cpu_usage{host_id="m1",service_name="CTRL"} 0.3366197347640991
-tigergraph_cpu_usage{host_id="m1",service_name="DICT"} 0.13882260024547577
-tigergraph_cpu_usage{host_id="m1",service_name="ETCD"} 1.021435022354126
-tigergraph_cpu_usage{host_id="m1",service_name="GPE"} 7.542555809020996
-tigergraph_cpu_usage{host_id="m1",service_name="GSE"} 45.86964416503906
-tigergraph_cpu_usage{host_id="m1",service_name="GSQL"} 1.0639517307281494
-tigergraph_cpu_usage{host_id="m1",service_name="GUI"} 0.010601896792650223
-tigergraph_cpu_usage{host_id="m1",service_name="IFM"} 1.0899430513381958
-tigergraph_cpu_usage{host_id="m1",service_name="KAFKA"} 56.06120681762695
-tigergraph_cpu_usage{host_id="m1",service_name="KAFKACONN"} 1.8662768602371216
-tigergraph_cpu_usage{host_id="m1",service_name="KAFKASTRM-LL"} 0.9830034971237183
+tigergraph_cpu_usage{host_id="m1",service_name=""} 1.7602790594100952
+tigergraph_cpu_usage{host_id="m1",service_name="ADMIN"} 0.04377374425530434
+tigergraph_cpu_usage{host_id="m1",service_name="CTRL"} 0.03333035483956337
+tigergraph_cpu_usage{host_id="m1",service_name="DICT"} 0.02717098779976368
+tigergraph_cpu_usage{host_id="m1",service_name="ETCD"} 0.06599369645118713
+tigergraph_cpu_usage{host_id="m1",service_name="EXE"} 0.3078765571117401
+tigergraph_cpu_usage{host_id="m1",service_name="GPE"} 0.057431410998106
+tigergraph_cpu_usage{host_id="m1",service_name="GSQL"} 0.42731526494026184
+tigergraph_cpu_usage{host_id="m1",service_name="GUI"} 0.0015482305316254497
+tigergraph_cpu_usage{host_id="m1",service_name="IFM"} 0.06652917712926865
+tigergraph_cpu_usage{host_id="m1",service_name="KAFKA"} 0.7873504757881165
+tigergraph_cpu_usage{host_id="m1",service_name="KAFKACONN"} 0.6024601459503174
+tigergraph_cpu_usage{host_id="m1",service_name="KAFKASTRM-LL"} 0.26026034355163574
 tigergraph_cpu_usage{host_id="m1",service_name="NGINX"} 0
-tigergraph_cpu_usage{host_id="m1",service_name="RESTPP"} 13.063582420349121
-tigergraph_cpu_usage{host_id="m1",service_name="TS3"} 0.1956222653388977
-tigergraph_cpu_usage{host_id="m1",service_name="TS3SERV"} 0.1768123060464859
-tigergraph_cpu_usage{host_id="m1",service_name="ZK"} 0.25204044580459595
+tigergraph_cpu_usage{host_id="m1",service_name="RESTPP"} 0.848330557346344
+tigergraph_cpu_usage{host_id="m1",service_name="ZK"} 0.08272281289100647
 # HELP tigergraph_diskspace_free Free Disk space in megabytes by directory.
 # TYPE tigergraph_diskspace_free gauge
-tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph",path_name="Home"} 188097.546875
-tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/gstore",path_name="Gstore"} 188097.546875
-tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/kafka",path_name="Kafka"} 188097.546875
-tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/log",path_name="Log"} 188097.546875
+tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph",path_name="Home"} 59276.48828125
+tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/gstore",path_name="Gstore"} 59276.4921875
+tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/kafka",path_name="Kafka"} 59276.4921875
+tigergraph_diskspace_free{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/log",path_name="Log"} 59276.484375
 # HELP tigergraph_diskspace_usage Disk usage in megabytes by directory.
 # TYPE tigergraph_diskspace_usage gauge
-tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph",path_name="Home"} 7107.47509765625
-tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/gstore",path_name="Gstore"} 579.0476684570312
-tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/kafka",path_name="Kafka"} 1164.056640625
-tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/log",path_name="Log"} 255.07992553710938
+tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph",path_name="Home"} 47280.34765625
+tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/gstore",path_name="Gstore"} 0
+tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/data/kafka",path_name="Kafka"} 0.85546875
+tigergraph_diskspace_usage{host_id="m1",mount_point="/",path="/home/tigergraph/tigergraph/log",path_name="Log"} 4.1015625
+# HELP tigergraph_memory_available Memory available in megabytes for programs to allocate
+# TYPE tigergraph_memory_available gauge
+tigergraph_memory_available{host_id="m1",service_name=""} 26603
+# HELP tigergraph_memory_total Total memory of the node in megabytes
+# TYPE tigergraph_memory_total gauge
+tigergraph_memory_total{host_id="m1",service_name=""} 32092
 # HELP tigergraph_memory_usage Memory usage in megabytes by component. Service name empty means usage of the whole node
 # TYPE tigergraph_memory_usage gauge
-tigergraph_memory_usage{host_id="m1",service_name=""} 6452
-tigergraph_memory_usage{host_id="m1",service_name="ADMIN"} 44
-tigergraph_memory_usage{host_id="m1",service_name="CTRL"} 33
-tigergraph_memory_usage{host_id="m1",service_name="DICT"} 35
-tigergraph_memory_usage{host_id="m1",service_name="ETCD"} 22
-tigergraph_memory_usage{host_id="m1",service_name="GPE"} 682
-tigergraph_memory_usage{host_id="m1",service_name="GSE"} 1129
-tigergraph_memory_usage{host_id="m1",service_name="GSQL"} 287
-tigergraph_memory_usage{host_id="m1",service_name="GUI"} 28
-tigergraph_memory_usage{host_id="m1",service_name="IFM"} 33
-tigergraph_memory_usage{host_id="m1",service_name="KAFKA"} 646
-tigergraph_memory_usage{host_id="m1",service_name="KAFKACONN"} 2182
-tigergraph_memory_usage{host_id="m1",service_name="KAFKASTRM-LL"} 401
-tigergraph_memory_usage{host_id="m1",service_name="NGINX"} 2
-tigergraph_memory_usage{host_id="m1",service_name="RESTPP"} 295
-tigergraph_memory_usage{host_id="m1",service_name="TS3"} 20
-tigergraph_memory_usage{host_id="m1",service_name="TS3SERV"} 21
-tigergraph_memory_usage{host_id="m1",service_name="ZK"} 116
+tigergraph_memory_usage{host_id="m1",service_name=""} 4555
+tigergraph_memory_usage{host_id="m1",service_name="ADMIN"} 55
+tigergraph_memory_usage{host_id="m1",service_name="CTRL"} 39
+tigergraph_memory_usage{host_id="m1",service_name="DICT"} 48
+tigergraph_memory_usage{host_id="m1",service_name="ETCD"} 26
+tigergraph_memory_usage{host_id="m1",service_name="EXE"} 44
+tigergraph_memory_usage{host_id="m1",service_name="GPE"} 127
+tigergraph_memory_usage{host_id="m1",service_name="GSQL"} 891
+tigergraph_memory_usage{host_id="m1",service_name="GUI"} 33
+tigergraph_memory_usage{host_id="m1",service_name="IFM"} 36
+tigergraph_memory_usage{host_id="m1",service_name="KAFKA"} 428
+tigergraph_memory_usage{host_id="m1",service_name="KAFKACONN"} 564
+tigergraph_memory_usage{host_id="m1",service_name="KAFKASTRM-LL"} 334
+tigergraph_memory_usage{host_id="m1",service_name="NGINX"} 4
+tigergraph_memory_usage{host_id="m1",service_name="RESTPP"} 340
+tigergraph_memory_usage{host_id="m1",service_name="ZK"} 95
 # HELP tigergraph_network_connections Number of open TCP connections.
 # TYPE tigergraph_network_connections gauge
-tigergraph_network_connections{host_id="m1",ip="10.128.0.203"} 477
+tigergraph_network_connections{host_id="m1"} 202
 # HELP tigergraph_network_traffic Network traffic in bytes since the service started.
 # TYPE tigergraph_network_traffic gauge
-tigergraph_network_traffic{direction="incoming",host_id="m1",ip="10.128.0.203"} 4.579066608e+09
-tigergraph_network_traffic{direction="outgoing",host_id="m1",ip="10.128.0.203"} 4.579066608e+09
+tigergraph_network_traffic{direction="incoming",host_id="m1"} 1.2802625793e+10
+tigergraph_network_traffic{direction="outgoing",host_id="m1"} 1.00515261e+08
 # HELP tigergraph_service_status Tigergraph service status. Partiton or replica empty means no partition or replica for that service.
 # TYPE tigergraph_service_status gauge
 tigergraph_service_status{partition="",replica="1",service_name="ADMIN"} 6
@@ -524,13 +532,11 @@ tigergraph_service_status{partition="",replica="1",service_name="KAFKA"} 6
 tigergraph_service_status{partition="",replica="1",service_name="KAFKACONN"} 6
 tigergraph_service_status{partition="",replica="1",service_name="NGINX"} 6
 tigergraph_service_status{partition="",replica="1",service_name="RESTPP"} 6
-tigergraph_service_status{partition="",replica="1",service_name="TS3SERV"} 6
 tigergraph_service_status{partition="",replica="1",service_name="ZK"} 6
 tigergraph_service_status{partition="1",replica="",service_name="EXE"} 6
 tigergraph_service_status{partition="1",replica="",service_name="KAFKASTRM-LL"} 6
-tigergraph_service_status{partition="1",replica="",service_name="TS3"} 6
-tigergraph_service_status{partition="1",replica="1",service_name="GPE"} 6
-tigergraph_service_status{partition="1",replica="1",service_name="GSE"} 6
+tigergraph_service_status{partition="1",replica="1",service_name="GPE"} 9
+tigergraph_service_status{partition="1",replica="1",service_name="GSE"} 27
 ----
 --
 ====


### PR DESCRIPTION
Ticket: https://graphsql.atlassian.net/browse/DOC-2302
this PR is for porting DOC-2246 to 3.11.0
original PR: https://github.com/tigergraph/server-docs/pull/488
