### PR TITLE
Update gsql-endpoints.adoc

### DIFF
--- a/modules/API/pages/gsql-endpoints.adoc
+++ b/modules/API/pages/gsql-endpoints.adoc
@@ -1793,7 +1793,7 @@ Sample Response::
 
 '''
 
-== loading job
+== Loading job
 
 === get loading job names
 
@@ -3303,7 +3303,7 @@ Sample Response::
 
 '''
 
-== templeta query
+== Template query
 
 === get all package names
 


### PR DESCRIPTION
1. Updated spelling mistake from "templeta query" to "template query".
2. Updated lowercase heading to match uppercase first char for consistency.