### PR TITLE
DOC-2346 Fix cdc-setup typo (3.10 - 4.1)

### DIFF
--- a/modules/system-management/pages/change-data-capture/cdc-setup.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-setup.adoc
@@ -127,7 +127,7 @@ Next, start a Zookeeper server
 ----
 KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
 
-KAFKA_ROOT/bin/zookeeper-server-start.sh $KAFKA_ROOT/config/zookeeper.properties
+$KAFKA_ROOT/bin/zookeeper-server-start.sh $KAFKA_ROOT/config/zookeeper.properties
 ----
 Now, start a Kafka server
 +


### PR DESCRIPTION
Added `$` in $KAFKA_ROOT/bin/zookeeper-server-start.sh $KAFKA_ROOT/config/zookeeper.properties