### PR TITLE
Fix typo in point-in-time-restore.adoc (4.1)

### DIFF
--- a/modules/backup-and-restore/pages/point-in-time-restore.adoc
+++ b/modules/backup-and-restore/pages/point-in-time-restore.adoc
@@ -1,7 +1,7 @@
 = Point-in-Time Restore
 
 Point-in-Time Restore, introduced in version 4.1, enables users to restore the database to a previous time point using previously made backups, even though no backup was conducted at exactly that time point.
-This feature replies on the user having made one or more xref:tigergraph-server:backup-and-restore:differential-backups.adoc[differential backups].
+This feature relies on the user having made one or more xref:tigergraph-server:backup-and-restore:differential-backups.adoc[differential backups].
 
 == Usage
 


### PR DESCRIPTION
changed from `replies` to `relies`