### PR TITLE
Update README.adoc for link fix

### DIFF
--- a/modules/data-querying/pages/README.adoc
+++ b/modules/data-querying/pages/README.adoc
@@ -4,3 +4,5 @@ In TigerGraph, users query data using the GSQL Query Language.
 Unlike traditional query languages for relational databases, a GSQL query is designed to be a saved prodecure containing a series of declaration, data-manipulation, data-modification, and output statements. 
 
 To learn about the syntax and the statements available in the GSQL Query Language, see xref:3.2@gsql-ref:querying:introduction-query.adoc[GSQL Language Reference: Querying.]
+
+Clicking on above link shows this url on address bar: https://docs.tigergraph.com/tigergraph-server/4.1/data-querying/readme#3.2@gsql-ref:querying:introduction-query.adoc, but it doesn't redirect to anywhere.


### PR DESCRIPTION
Clicking on the link shows this url on address bar: https://docs.tigergraph.com/tigergraph-server/4.1/data-querying/readme#3.2@gsql-ref:querying:introduction-query.adoc, but it doesn't redirect to anywhere.