### PR TITLE
DOC-2331-CDC-HA-3.11-fixes

### DIFF
--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -40,9 +40,9 @@ Audit logs now include `gadmin` activity, for more complete audit coverage.
 
 * **xref:{page-component-version}@tigergraph-server:data-loading:data-loading-v2.adoc[Data Loading HA (Beta)]**:
 If the database is replicated, this data loading mode offers faster loading, reduced disk usage, and HA with automatic failover.
-Available for TigerGraph's xref:tigergraph-server:data-loading:manage-data-source.adoc[data streaming connectors] for cloud storage, Kafka, data warehouses, and Spark.
+Available for TigerGraph's xref:{page-component-version}@tigergraph-server:data-loading:manage-data-source.adoc[data streaming connectors] for cloud storage, Kafka, data warehouses, and Spark.
 
-* **xref:tigergraph-server:system-management:change-data-capture/cdc-overview.adoc#_cdc_ha[Change Data Capture (CDC) HA]**:
+* **xref:{page-component-version}@tigergraph-server:system-management:change-data-capture/cdc-overview.adoc#_cdc_ha[Change Data Capture (CDC) HA]**:
 CDC continues to function as long as at least one replica per partition is online.
 Previously, Replica 1 needed to remain operational.
 

--- a/modules/system-management/pages/change-data-capture/cdc-overview.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-overview.adoc
@@ -39,9 +39,9 @@ The "uid" field in generated CDC message results as "UNKNOWN".
 
 == CDC HA
 
-High Availability (HA) support for the CDC service was introduced in version 4.1.0. Before this version, the CDC service (manager) operated exclusively on replica 1 of each GPE partition.
+High Availability (HA) support for the CDC service was introduced in version 3.11. Before this version, the CDC service (manager) operated exclusively on replica 1 of each GPE partition.
 
-As of version 4.1.0, the CDC service operates on the GPE leader within each GPE partition. In each GPE partition, as long as there is at least one live node, a leader will be elected, and the CDC service should function normally.
+As of version 3.11, the CDC service operates on the GPE leader within each GPE partition. In each GPE partition, as long as there is at least one live node, a leader will be elected, and the CDC service should function normally.
 
 For instance, in a 2x2 cluster, if only GPE_1#1 and GPE_2#2 are online among all GPE servers, the CDC service should still operate without issues.
 


### PR DESCRIPTION
1) Change statement "as of version 4.1" to "as of version 3.11".

2) In the Release Notes, as "page-component-version}@" to the links to the CDC HA feature, so it links to the right version.