### PR TITLE
Typo in user-management.adoc [4.1 - and earlier?]

### DIFF
--- a/modules/user-access/pages/user-management.adoc
+++ b/modules/user-access/pages/user-management.adoc
@@ -108,7 +108,7 @@ for special case use “`“ username“`“ to include the username
 
 == View roles assignments and login attempts
 The `SHOW USER` command displays the role assignments, as well as the login attempts,  of the current user.
-If the current user hsa the `READ_USER` privilege
+If the current user has the `READ_USER` privilege
 
 === Syntax
 


### PR DESCRIPTION
typo correction from `hsa` to `has`