### PR TITLE
DOC-2401 doc for adding built-in role globalobserver [4.1]

### DIFF
--- a/modules/release-notes/pages/index.adoc
+++ b/modules/release-notes/pages/index.adoc
@@ -52,6 +52,8 @@ Audit logs now include `gadmin` activity, for more complete audit coverage.
 
 * [4.1.1] **xref:4.1@tigergraph-server:troubleshooting:audit-log.adoc#_gsql_service_audit_logs[More detailed information in audit logs]**. Also, an authorized admin user can configure the audit logs to include PII.
 
+* **xref:4.1@tigergraph-server:user-access:role-management.adoc#_built_in_roles[New Built-in Role]**: globalobserver
+- The globalobserver role introduces read-only access for schemas and loading jobs on the global scope
 
 === High Availability (HA) Enhancements
 


### PR DESCRIPTION
Adding New Built-in Role: globalobserver to the Release note
