### PR TITLE
DOC-1620-Server-Size-limits-for-attributes-4.0

### DIFF
--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1477,8 +1477,8 @@ a|
 
 || `FieldSizeLimit`, GPE.BasicConfig.Env
 a|
-* Specifies the size threshold for a single FIELD in a data record 
-* The value must be uint64_t type and in unit: Byte.The default value is 104,857,600 bytes i.e. 100MB and maximum value is 18446744073709551615 bytes i.e. 17,179,869,184 MB. 
+* Specifies the maximum number of bytes (as an unsigned integer `UINT`) for a single field in a data record
+* The default is 104,857,600 = 100 MB. The maximum is 2^64 -1 = 16 exabytes
 | `FieldSizeLimit=20000`
 
 || `ContainerLengthLimit`, GPE.BasicConfig.Env

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1485,7 +1485,7 @@ a|
 a|
 * Specifies the threshold for the maximum number of entries allowed in a container
 * The default value is 1M
-| `ContainerLengthLimit`
+| `ContainerLengthLimit=10000`
 
 |GSE
 | `ServFromDisk`,

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1478,13 +1478,13 @@ a|
 || `FieldSizeLimit`, GPE.BasicConfig.Env
 a|
 * Specifies the size threshold for a single FIELD in a data record 
-* The default value is 100MB. 
+* The value must be uint64_t type and in unit: Byte.The default value is 104,857,600 bytes i.e. 100MB and maximum value is 18446744073709551615 bytes i.e. 17,179,869,184 MB. 
 | `FieldSizeLimit=20000`
 
 || `ContainerLengthLimit`, GPE.BasicConfig.Env
 a|
-* Specifies the threshold for the maximum number of entries allowed in a container
-* The default value is 1M
+* Specifies the threshold for number of entries allowed in a container
+* The value must be uint64_t type and in unit: Byte.The default value is 1,048,576 bytes i.e. 1MB and maximum value is 18446744073709551615 bytes i.e. 17,179,869,184 MB. 
 | `ContainerLengthLimit=10000`
 
 |GSE

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1479,7 +1479,7 @@ a|
 a|
 * Specifies the size threshold for a single FIELD in a data record 
 * The default value is 100MB. 
-| `FieldSizeLimit`
+| `FieldSizeLimit=5`
 
 || `ContainerLengthLimit`, GPE.BasicConfig.Env
 a|

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1483,7 +1483,7 @@ a|
 
 || `ContainerLengthLimit`, GPE.BasicConfig.Env
 a|
-* Specifies the threshold for number of entries allowed in a container
+* Specifies the maximum number of entries allowed in a container
 * The value must be uint64_t type and in unit: Byte.The default value is 1,048,576 bytes i.e. 1MB and maximum value is 18446744073709551615 bytes i.e. 17,179,869,184 MB. 
 | `ContainerLengthLimit=10000`
 

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1475,6 +1475,18 @@ a|
 * The default value is 0. When the value is 0, the threshold is dynamically decided by TigerGraph, based on current memory usage statistics.
 | `TransactionSizeLimit=1073741824`
 
+|| `FieldSizeLimit`, GPE.BasicConfig.Env
+a|
+* Specifies the size threshold for a single FIELD in a data record 
+* The default value is 100MB. 
+| `FieldSizeLimit`
+
+|| `ContainerLengthLimit`, GPE.BasicConfig.Env
+a|
+* Specifies the threshold for the maximum number of entries allowed in a container
+* The default value is 1M
+| `ContainerLengthLimit`
+
 |GSE
 | `ServFromDisk`,
 GSE.BasicConfig.Env

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1484,7 +1484,7 @@ a|
 || `ContainerLengthLimit`, GPE.BasicConfig.Env
 a|
 * Specifies the maximum number of entries allowed in a container
-* The value must be uint64_t type and in unit: Byte.The default value is 1,048,576 bytes i.e. 1MB and maximum value is 18446744073709551615 bytes i.e. 17,179,869,184 MB. 
+* The default value is 1,048,576 bytes = 1MB .The maximum is 2^64 -1 = 16 exabytes
 | `ContainerLengthLimit=10000`
 
 |GSE

--- a/modules/reference/pages/configuration-parameters.adoc
+++ b/modules/reference/pages/configuration-parameters.adoc
@@ -1479,7 +1479,7 @@ a|
 a|
 * Specifies the size threshold for a single FIELD in a data record 
 * The default value is 100MB. 
-| `FieldSizeLimit=5`
+| `FieldSizeLimit=20000`
 
 || `ContainerLengthLimit`, GPE.BasicConfig.Env
 a|


### PR DESCRIPTION
To add FieldSizeLimit and ContainerLengthLimit to configuration parameters table