### PR TITLE
DOC-2486 doc(k8s): Add a new section and link to getting started with Kubernetes;

### DIFF
--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -2,6 +2,7 @@
 * xref:index.adoc[Get Started]
 ** Installation
 *** xref:docker.adoc[On Docker]
+*** xref:kubernetes.adoc[On Kubernetes]
 *** xref:cloud-images/index.adoc[On Cloud Marketplace]
 **** xref:cloud-images/aws.adoc[AWS]
 **** xref:cloud-images/azure.adoc[Azure]

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -9,6 +9,9 @@ If you are a Mac or Windows user, we recommend you use Docker to start up TigerG
 
 NOTE: The Docker image version of TigerGraph is for personal or R&D use and not for production use.
 
+== xref:tigergraph-server:getting-started:kubernetes.adoc[]
+
+Deploy a TigerGraph cluster on GKE, EKS, AKS, or OpenShift using the TigerGraph Operator.
 
 == xref:tigergraph-server:getting-started:linux.adoc[Get Started on Linux]
 

--- a/modules/getting-started/pages/kubernetes.adoc
+++ b/modules/getting-started/pages/kubernetes.adoc
@@ -2,9 +2,8 @@
 
 To get started go to our https://github.com/tigergraph/ecosys/blob/master/k8s/docs/02-get-started/get_started.md[Get Started] GitHub page where you will install the Operator and provision your first cluster using the Operator.
 
-== Supported cloud platforms
-The TigerGraph Kubernetes Operator is platform-agnostic.
-You should be able to use the Operator on any cloud platform that provides a Kubernetes service.
+Use the Operator on any cloud platform with Kubernetes support.
+
 TigerGraph has verified the full functionality of the operator on the Kubernetes services of the following platform:
 
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-gke.md[Google Kubernetes Engine (GKE)]
@@ -12,6 +11,6 @@ TigerGraph has verified the full functionality of the operator on the Kubernetes
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-eks.md[AWS Elastic Kubernetes Service (EKS)]
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-aks.md[Azure Kubernetes Service (AKS)]
 
-Additionally, TigerGraph Kubernetes Operator can be installed and deployed without internet access
+Additionally, TigerGraph Kubernetes Operator can be installed and deployed without internet access.
 
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/deploy-without-internet.md[Install and Deploy without internet access]

--- a/modules/getting-started/pages/kubernetes.adoc
+++ b/modules/getting-started/pages/kubernetes.adoc
@@ -1,0 +1,17 @@
+= Getting started on Kubernetes
+
+To get started go to our https://github.com/tigergraph/ecosys/blob/master/k8s/docs/02-get-started/get_started.md[Get Started] GitHub page where you will install the Operator and provision your first cluster using the Operator.
+
+== Supported cloud platforms
+The TigerGraph Kubernetes Operator is platform-agnostic.
+You should be able to use the Operator on any cloud platform that provides a Kubernetes service.
+TigerGraph has verified the full functionality of the operator on the Kubernetes services of the following platform:
+
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-gke.md[Google Kubernetes Engine (GKE)]
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-openshift.md[Red Hat OpenShift]
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-eks.md[AWS Elastic Kubernetes Service (EKS)]
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-aks.md[Azure Kubernetes Service (AKS)]
+
+Additionally, TigerGraph Kubernetes Operator can be installed and deployed without internet access
+
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/deploy-without-internet.md[Install and Deploy without internet access]

--- a/modules/kubernetes/pages/k8s-operator/index.adoc
+++ b/modules/kubernetes/pages/k8s-operator/index.adoc
@@ -32,6 +32,7 @@ TigerGraph has verified the full functionality of the operator on the Kubernetes
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-gke.md[Google Kubernetes Engine (GKE)]
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-openshift.md[Red Hat OpenShift]
 * https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-eks.md[AWS Elastic Kubernetes Service (EKS)]
+* https://github.com/tigergraph/ecosys/blob/master/k8s/docs/03-deploy/tigergraph-on-aks.md[Azure Kubernetes Service (AKS)]
 
 Additionally, TigerGraph Kubernetes Operator can be installed and deployed without internet access
 


### PR DESCRIPTION
Original TP ticket: https://graphsql.atlassian.net/browse/TP-7295
Doc ticket: https://graphsql.atlassian.net/browse/DOC-2486

# Description

https://docs.tigergraph.com/tigergraph-server/4.1/getting-started/  

This page is missing info and a link about getting started with k8s. We should add a link to our k8s quick start to point the users. 

Additionally, it needs to update the supported K8s providers and links since AKS GA has been released since 4.1.1(Operator 1.3.0).