### PR TITLE
DOC-2525 Correct "VERTEX" spelling[3.11]

### DIFF
--- a/modules/cluster-and-ha-management/pages/crr-index.adoc
+++ b/modules/cluster-and-ha-management/pages/crr-index.adoc
@@ -68,7 +68,7 @@ CRR logic is divided into two layers:
 
 [NOTE]
 ====
-A "replica" in Kafka topic context is the committed operation of a write transaction ( `CREATE VETEX Person`) that happened successfully on the primary.
+A "replica" in Kafka topic context is the committed operation of a write transaction ( `CREATE VERTEX Person`) that happened successfully on the primary.
 Every replica has a unique identification which is consistent between primary and DR.
 
 Kafka MirrorMaker is a stand-alone tool (out-of-the-box from TigerGraph) for copying data between two Kafka, in this specific case between primary Kafka and DR Kafka.


### PR DESCRIPTION
Spelling changed from "VETEX" --> "VERTEX"