### PR TITLE
DOC-2334-cdc-setup-proofread

### DIFF
--- a/modules/system-management/pages/change-data-capture/cdc-setup.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-setup.adoc
@@ -2,10 +2,11 @@
 
 When using the CDC feature, a “CDC service” running in GPE nodes will process data updates ("deltas") and write CDC messages to the external Kafka maintained by the user.
 
-== Important
-
+[IMPORTANT]
+====
 * **External Kafka Cluster** : Users must set up and manage their own Kafka cluster. The TigerGraph CDC service will send CDC messages to this external Kafka cluster.
-* For guidance on setting up the external Kafka service, refer to the https://kafka.apache.org/quickstart[Official Apache Kafka documentation]. 
+* For guidance on setting up the external Kafka service, refer to the https://kafka.apache.org/quickstart[Official Apache Kafka documentation].
+====
 
 == Setup Configuration
 TigerGraph employs librdkafka 1.1.0 for the Kafka producer in the CDC service.
@@ -13,11 +14,11 @@ Refer to the Global configuration properties and the Topic configuration propert
 
 === Configuring CDC Producer and Topic Settings
 
-Use the following gadmin commands to configure the CDC producer and topic settings in TigerGraph.
+Use the following `gadmin` commands to configure the CDC producer and topic settings in TigerGraph.
 
 === Applying Configuration Changes
 
-* If you modify any configuration using gadmin config, ensure to run the following command to apply the changes:
+* If you modify any configuration using gadmin config, ensure to run the following commands to apply the changes:
 [source, console]
 ----
 gadmin config apply
@@ -29,13 +30,6 @@ gadmin restart gpe restpp
 
 Controls whether CDC is enabled or disabled.
 
-.This is the CDC enable config entry:
-
-[source, console]
-----
-gadmin config entry
-----
-
 Enable or disable CDC using:
 
 [source, console]
@@ -44,19 +38,23 @@ gadmin config set System.CDC.Enable true // To enable CDC
 gadmin config set System.CDC.Enable false //To disable CDC
 ----
 
-[NOTE]:CDC messages are generated only after enabling the CDC service and restarting the system.
+NOTE: CDC messages are generated only after enabling the CDC service and restarting the system.
 
 === System.CDC.ProducerConfig
-Specifies properties for the CDC producer.Properties are passed through a file, with each line adhering to the format `<property name>=<property value>` separated by “new line”.
 
-.This is the CDC producer config entry:
+Specifies properties for the CDC producer.
 
-[console]
-----
-gadmin config entry System.CDC.ProducerConfig
-----
+To update properties non-interactively, create a file (e.g., `cdc_producer_config`) where each line has the
+format `<property name>=<property value>` separated by “new line”.
+Then use
 
-[NOTE]: It is mandatory to include the property `bootstrap.servers` , which specifies the IP and port of the external Kafka cluster for CDC:
+`gadmin config set System.CDC.ProducerConfig @<filename>`
+
+to read in the settings.
+
+IMPORTANT: It is mandatory to include the property `bootstrap.servers` , which specifies the IP and port of the external Kafka cluster for CDC.
+
+Example:
 
 [console]
 ----
@@ -67,9 +65,18 @@ echo -e "bootstrap.servers=$(gmyip):9092\nenable.idempotence=true" > /home/tiger
 
 gadmin config set System.CDC.ProducerConfig @/home/tigergraph/test_cdc/cdc_producer_config
 ----
-The full list of entries for configuration file of `System.CDC.ProducerConfig` can be viewed in table "Global configuration properties" here: https://github.com/confluentinc/librdkafka/blob/v1.1.0/CONFIGURATION.md#global-configuration-properties.
 
-[NOTE]:Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable. 
+
+
+If you prefer to enter the property values interactively, use
+
+`gadmin config entry System.CDC.ProducerConfig`
+
+This will walk you through the full set of properties for this component, with a description and the current value for each item.
+
+The full list of entries for configuration file of `System.CDC.ProducerConfig` can be viewed in the table "Global configuration properties" at https://github.com/confluentinc/librdkafka/blob/v1.1.0/CONFIGURATION.md#global-configuration-properties.
+
+NOTE: Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable.
 
 ==== Kafka Security
 
@@ -77,8 +84,8 @@ To secure communication with the external Kafka cluster for CDC, configure authe
 
 [NOTE]
 ====
-1. When using local path in any entry, for example: `sasl.kerberos.keytab` or `ssl.ca.location`, the local file must exist and be consistent on all nodes in TigerGraph cluster.
-2. The entry `sasl.jaas.config` is not applicable, because it is only for JAVA-based kafka client, while librdkafka in TigerGraph engine is C++ library.
+1. When using a local path in any entry (e.g., `sasl.kerberos.keytab` or `ssl.ca.location`), the local file must exist and be consistent across all nodes in the TigerGraph cluster.
+2. The entry `sasl.jaas.config` is not applicable, because it is specific to JAVA-based kafka clients, while librdkafka in TigerGraph engine is a C++ library.
 ====
 
 Example 1: Authenticating with SASL/PLAIN
@@ -116,24 +123,26 @@ ssl.key.location=<path/to/key.pem>
 For more details on SASL with librdkafka, refer to the: https://github.com/confluentinc/librdkafka/wiki/Using-SASL-with-librdkafka
 
 === System.CDC.TopicConfig
-.This is the CDC topic config entry:
-[console]
-----
-gadmin config entry System.CDC.TopicConfig
-----
 
-Utilize a file to pass properties, separating them with a "new line."
-The prescribed format for each line is `<property name>=<property value>`.
-It is imperative to employ the property name to designate the CDC topic, such as `name=<CDC topic name>`, as in the following example:
+To update properties non-interactively, create a file (e.g., `cdc_producer_config`) where each line has the
+format `<property name>=<property value>` separated by “new line”.
+Then use
+
+`gadmin config set System.CDC.TopicConfig @<filename>`
+
+to read in the settings.
+
+IMPORTANT: It is mandatory to include the property `name` to designate the CDC topic, as in the following example:
+
 [console]
 ----
 echo -e "name=cdc_topic" > /home/tigergraph/test_cdc/cdc_topic_config
 
 gadmin config set System.CDC.TopicConfig @/home/tigergraph/test_cdc/cdc_topic_config
 ----
-The full list of entries for configuration file of `System.CDC.TopicConfig` can be viewed in table "Topic configuration properties" here: https://github.com/edenhill/librdkafka/blob/v1.1.0/CONFIGURATION.md#topic-configuration-properties.
+The full list of entries for configuration file of `System.CDC.TopicConfig` can be viewed in the table "Topic configuration properties" at https://github.com/edenhill/librdkafka/blob/v1.1.0/CONFIGURATION.md#topic-configuration-properties.
 
-[NOTE]:Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable.
+NOTE: Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable.
 
 For other configuration settings please see the xref:_other_configuration_settings_table[Other Configuration Settings Table].
 
@@ -192,7 +201,8 @@ KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
 $KAFKA_ROOT/bin/kafka-server-start.sh $KAFKA_ROOT/config/server.properties
 ----
 +
-[NOTE]:To listen to messages produced from remote servers, edit the `server.properties` to add `listeners=PLAINTEXT://<my ip>:9092`.For the value of `<my ip>`,  use the command `ifconfig` or `ip addr show`, and find the ip after `inet`.
+NOTE: To listen to messages produced from remote servers, edit the `server.properties` to add `listeners=PLAINTEXT://<my ip>:9092`.
+For the value of `<my ip>`,  use the command `ifconfig` or `ip addr show`, and find the ip after `inet`.
 
 +
 ***(Optional)* clear Kafka topic**

--- a/modules/system-management/pages/change-data-capture/cdc-state-monitoring.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-state-monitoring.adoc
@@ -1,7 +1,8 @@
 = CDC State Monitoring
 
 == State Monitoring
-.Check the state of CDC Service with this command:
+Check the state of CDC Service with this command:
+
 [console]
 ----
 grun_p gpe "cat $(gadmin config get System.DataRoot)/gstore/0/part/cdc.yaml"
@@ -12,7 +13,7 @@ The cdc state file should only exist on GPE Replica 1 node of each partition:
 * `GPE_1#1`
 * `GPE_2#1`
 
-.The response will look like this:
+.Example Response
 [console]
 ----
 ------------------ Output example for cdc.yaml on 1x2 cluster -------------------
@@ -25,7 +26,7 @@ index: 0
 cat: /home/tigergraph/tigergraph/data/gstore/0/part/cdc.yaml: No such file or directory
 ----
 
-.For each CDC state field, see the table below:
+.Information Fields for CDC Status Report
 [cols="2", separator=¦ ]
 |===
 ¦ Field ¦ Meaning
@@ -38,7 +39,7 @@ For a transaction, it’s the tid of the last delta batch for the transaction (m
 ¦ The `safe_persistent_tid` is the tid of the earliest delta batch among all open transactions that are not committed/rolled-back in CDC.
 If there’s no open transactions, this is the same as tid.
 
-All delta batches with `tid < safe_persistent_tid >` must have been written to external kafka.
+All delta batches with `tid <safe_persistent_tid>` must have been written to external kafka.
 
 ¦ `split_index`
 ¦ For non-transaction, it’s always 0. For transactions, the split_index is the index of the delta batch that was most recently written to external kafka among all delta batches for the same transaction.
@@ -49,13 +50,13 @@ All delta batches with `tid < safe_persistent_tid >` must have been written to e
 
 == State of DIM Service
 
-.Check the state of DIM(Deleted Id Map) service with this command:
+.Command to check the state of DIM(Deleted Id Map) service
 [console]
 ----
 grun_p gpe "cat $(gadmin config get System.DataRoot)/gstore/0/part/deleted_idmap_state.yaml"
 ----
 
-.Check disk usage of DIM(Deleted Id Map) service with this command:
+.Command to check disk usage of DIM(Deleted Id Map) service
 [console]
 ----
 grun_p gpe "du -sh $(gadmin config get System.DataRoot)/gstore/0/part/deletedID_store"
@@ -63,7 +64,7 @@ grun_p gpe "du -sh $(gadmin config get System.DataRoot)/gstore/0/part/deletedID_
 
 The dim state file exists on all GPE nodes, unlike the cdc state file.
 
-.The response will look like this:
+.Example response for DIM state
 [console]
 ----
 ------------ Output example for deleted_idmap_state.yaml on 1x2 cluster ------------
@@ -84,7 +85,7 @@ purged_deletedvid_curr_tid: 3752091
 The purging task runs every 30 minutes by default.
 ====
 
-.For each DIM state field, see the table below:
+.Information fields for DIM state report
 [cols="2", separator=¦ ]
 |===
 ¦ Field ¦ Meaning


### PR DESCRIPTION
Made a number of editorial improvements to the already-published DOC-2334 edits.

Summary:

* Instead of having plaintext "[NOTE]:<comment>", made use of Antora's syntax for automatic styling of "admonition" boxes (5 varieties: NOTE, IMPORTANT, TIP, WARNING, CAUTION)
* Provided a clear, contextual explanation of what `gadmin config entry` does and how we propose to use it in this context.
* Applied some minor wording corrections or improvements, some which Anjali had proposed and somehow got overlooked, and some of my own.
* On the CDC State Monitor page, made a stylistic correction regarding code block or table **captions**

```
.For example, here is an example of the stylistically wrong use of a caption:
[console]
----
some code
----
```

A caption is a title. It should NOT read like a full sentence and NOT as an integral part of the discussion.  It should read like a simple noun or noun phrase, just giving a name to the table/figure.

```
.A proper caption
[console]
----
some code
----
```