### PR TITLE
DOC-2334-cdc-doc-improv-port-4.1

### DIFF
--- a/modules/system-management/pages/change-data-capture/cdc-setup.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-setup.adoc
@@ -1,63 +1,62 @@
 = CDC Setup
+:description: How to set up cross region replication
 
 When using the CDC feature, a “CDC service” running in GPE nodes will process data updates ("deltas") and write CDC messages to the external Kafka maintained by the user.
 
 [IMPORTANT]
 ====
-Users are required to establish and manage an external Kafka service independently from TigerGraph.
-The TigerGraph CDC service will then generate CDC messages directed to the external Kafka service.
-For guidance on setting up the external Kafka service, refer to the https://kafka.apache.org/quickstart[Official Apache Kafka documentation].
+* **External Kafka Cluster** : Users must set up and manage their own Kafka cluster. The TigerGraph CDC service will send CDC messages to this external Kafka cluster.
+* For guidance on setting up the external Kafka service, refer to the https://kafka.apache.org/quickstart[Official Apache Kafka documentation].
 ====
 
 == Setup Configuration
 TigerGraph employs librdkafka 1.1.0 for the Kafka producer in the CDC service.
 Refer to the Global configuration properties and the Topic configuration properties sections of the librdkafka documentation for all other properties not mentioned in this guide, noting the applicable ones marked with “P”(Producer) or with “*” for both Producer and Consumer.
 
-To configure CDC Producer and Topic settings in TigerGraph, utilize gadmin commands below.
+=== Configuring CDC Producer and Topic Settings
 
-[NOTE]
-====
-If you use `gadmin config` to change any of these parameters, you need to run `gadmin config apply -y` for it to take effect.
-You can change multiple parameters and then run `gadmin config apply` for all of them together
+Use the following `gadmin` commands to configure the CDC producer and topic settings in TigerGraph.
 
-.After modifying, run the following command to apply the changes:
+=== Applying Configuration Changes
+
+* If you modify any configuration using gadmin config, ensure to run the following commands to apply the changes:
 [source, console]
 ----
 gadmin config apply
 gadmin restart gpe restpp
 ----
-====
 
 == CDC Configuration Parameters
 === System.CDC.Enable
 
-.This is the CDC enable config entry:
+Controls whether CDC is enabled or disabled.
+
+Enable or disable CDC using:
+
 [source, console]
 ----
-gadmin config entry
+gadmin config set System.CDC.Enable true // To enable CDC
+gadmin config set System.CDC.Enable false //To disable CDC
 ----
 
-=== System.CDC.Enable
-.Set it to true or false, to enable CDC or not as in these examples:
-[source, console]
-----
-gadmin config set System.CDC.Enable true
-gadmin config set System.CDC.Enable false
-----
-
-CDC messages will only generate after the CDC is enabled and services have been applied and restarted.
+NOTE: CDC messages are generated only after enabling the CDC service and restarting the system.
 
 === System.CDC.ProducerConfig
-.This is the CDC producer config entry:
-[console]
-----
-gadmin config entry System.CDC.ProducerConfig
-----
-This configuration entry is designated for the CDC producer.
 
-Properties are passed through a file, with each line adhering to the format `<property name>=<property value>` separated by “new line”.
+Specifies properties for the CDC producer.
 
-It is mandatory to include the property `bootstrap.servers`, specifying the IP and port for the broker(s) that the CDC producer connects to as in the example below:
+To update properties non-interactively, create a file (e.g., `cdc_producer_config`) where each line has the
+format `<property name>=<property value>` separated by “new line”.
+Then use
+
+`gadmin config set System.CDC.ProducerConfig @<filename>`
+
+to read in the settings.
+
+IMPORTANT: It is mandatory to include the property `bootstrap.servers` , which specifies the IP and port of the external Kafka cluster for CDC.
+
+Example:
+
 [console]
 ----
 mkdir -p /home/tigergraph/test_cdc
@@ -68,22 +67,83 @@ echo -e "bootstrap.servers=$(gmyip):9092\nenable.idempotence=true" > /home/tiger
 gadmin config set System.CDC.ProducerConfig @/home/tigergraph/test_cdc/cdc_producer_config
 ----
 
-=== System.CDC.TopicConfig
-.This is the CDC topic config entry:
+
+
+If you prefer to enter the property values interactively, use
+
+`gadmin config entry System.CDC.ProducerConfig`
+
+This will walk you through the full set of properties for this component, with a description and the current value for each item.
+
+The full list of entries for configuration file of `System.CDC.ProducerConfig` can be viewed in the table "Global configuration properties" at https://github.com/confluentinc/librdkafka/blob/v1.1.0/CONFIGURATION.md#global-configuration-properties.
+
+NOTE: Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable.
+
+==== Kafka Security
+
+To secure communication with the external Kafka cluster for CDC, configure authentication settings in System.CDC.ProducerConfig.
+
+[NOTE]
+====
+1. When using a local path in any entry (e.g., `sasl.kerberos.keytab` or `ssl.ca.location`), the local file must exist and be consistent across all nodes in the TigerGraph cluster.
+2. The entry `sasl.jaas.config` is not applicable, because it is specific to JAVA-based kafka clients, while librdkafka in TigerGraph engine is a C++ library.
+====
+
+Example 1: Authenticating with SASL/PLAIN
+
 [console]
 ----
-gadmin config entry System.CDC.TopicConfig
+security.protocol=SASL_PLAINTEXT
+sasl.mechanisms=PLAIN
+sasl.username=<username>
+sasl.password=<password>
 ----
 
-Utilize a file to pass properties, separating them with a "new line."
-The prescribed format for each line is `<property name>=<property value>`.
-It is imperative to employ the property name to designate the CDC topic, such as `name=<CDC topic name>`, as in the following example:
+Example 2: Authenticating with SASL/GSSAPI
+[console]
+----
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=GSSAPI
+sasl.kerberos.service.name=kafka
+sasl.kerberos.principal=<user@EXAMPLE.COM>
+sasl.kerberos.keytab=</path/to/user.keytab>
+----
+
+Example 3: Authenticating with SASL/PLAIN and Encrypted with SSL
+[console]
+----
+security.protocol=SASL_SSL
+sasl.mechanisms=PLAIN
+sasl.username=<username>
+sasl.password=<password>
+ssl.ca.location=<path/to/ca.pem>
+ssl.certificate.location=<path/to/cert.pem>
+ssl.key.location=<path/to/key.pem>
+----
+
+For more details on SASL with librdkafka, refer to the: https://github.com/confluentinc/librdkafka/wiki/Using-SASL-with-librdkafka
+
+=== System.CDC.TopicConfig
+
+To update properties non-interactively, create a file (e.g., `cdc_producer_config`) where each line has the
+format `<property name>=<property value>` separated by “new line”.
+Then use
+
+`gadmin config set System.CDC.TopicConfig @<filename>`
+
+to read in the settings.
+
+IMPORTANT: It is mandatory to include the property `name` to designate the CDC topic, as in the following example:
+
 [console]
 ----
 echo -e "name=cdc_topic" > /home/tigergraph/test_cdc/cdc_topic_config
 
 gadmin config set System.CDC.TopicConfig @/home/tigergraph/test_cdc/cdc_topic_config
 ----
+The full list of entries for configuration file of `System.CDC.TopicConfig` can be viewed in the table "Topic configuration properties" at https://github.com/edenhill/librdkafka/blob/v1.1.0/CONFIGURATION.md#topic-configuration-properties.
+
+NOTE: Only properties marked with P(Producer) or *(both Producer and Consumer) are applicable.
 
 For other configuration settings please see the xref:_other_configuration_settings_table[Other Configuration Settings Table].
 
@@ -91,37 +151,42 @@ For other configuration settings please see the xref:_other_configuration_settin
 
 This tutorial will walk you through how to set up a TigerGraph CDC service.
 
-. Setup external Kafka service for CDC messages
+. **Set Up the External Kafka Cluster for CDC**
 +
-.Download external Kafka package
+If you already have a running external Kafka cluster for CDC, this step can be skipped.
 +
-.First make the folder it will be downloaded to:
+.**Download external Kafka package**
++
+.**Create the directory where Kafka will be downloaded**:
+
 [console]
 ----
 mkdir -p /home/tigergraph/test_cdc/download_kafka
 ----
 +
-.Use this package:
+.**Use this package**:
 [console]
 ----
 `https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz`
 ----
 +
-.And run this command to download Kafka to the folder that was just created:
+.**Download Kafka**:
 [console]
 ----
 curl https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz | tar -xzf - -C "/home/tigergraph/test_cdc/download_kafka"
 ----
 +
-.Check if it's successfully downloaded and extracted with this command:
+.**Verify the download**:
 [console]
 ----
 ls -l /home/tigergraph/test_cdc/download_kafka
 ----
+
+. **Start the External Zookeeper and Kafka Cluster for CDC**
 +
-Next, start a Zookeeper server.
+.. Start the External Zookeeper Instance.
 +
-.Open a new terminal to start the Zookeeper service. Use the default configuration `Zookeeper.properties`, where it is using default port `2181`:
+Use the default configuration `zookeeper.properties`, where it is using default port `2181`:
 +
 [console]
 ----
@@ -129,9 +194,10 @@ KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
 
 $KAFKA_ROOT/bin/zookeeper-server-start.sh $KAFKA_ROOT/config/zookeeper.properties
 ----
-Now, start a Kafka server.
 +
-.Use the configuration file `server.properties`, where it is using default port `9092`.
+.. Start the External Kafka Cluster for CDC.
++
+Use the configuration file `server.properties`, where it is using default port `9092`.
 +
 If you have a cluster environment or if the external Kafka server is not local to the GPE servers, you need to add the following line to `server.properties` file, to enable listening to messages from remote servers:
 +
@@ -142,7 +208,7 @@ listeners=PLAINTEXT://<my_ip>:9092
 +
 To determine the value for `<my ip>`,  use the command `ifconfig` or `ip addr show`, and find the ip after `inet`.
 +
-Command to start a Kafka server:
+.Command to start a Kafka server:
 +
 [console]
 ----
@@ -151,23 +217,26 @@ KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
 $KAFKA_ROOT/bin/kafka-server-start.sh $KAFKA_ROOT/config/server.properties
 ----
 +
-*(Optional)* clear Kafka topic
+NOTE: To listen to messages produced from remote servers, edit the `server.properties` to add `listeners=PLAINTEXT://<my ip>:9092`.
+For the value of `<my ip>`,  use the command `ifconfig` or `ip addr show`, and find the ip after `inet`.
+
++
+***(Optional)* clear Kafka topic**
 +
 .Run this command to clear existing old Kafka messages in the Kafka.
 [console]
 ----
 MYIP=127.0.0.1
 
-KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1 
-
+KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
 $KAFKA_ROOT/bin/kafka-topics.sh --bootstrap-server $MYIP:9092 --delete --topic cdc_topic
 ----
 
-. Setup TigerGraph CDC service
+. **Set Up the TigerGraph CDC Service**
 +
-Now, start the CDC service in TigerGraph.
+After configuring the external Kafka cluster for CDC, set up the TigerGraph CDC service.
 +
-.Use the setup configuration commands as followed.
+.**Configure the CDC producer and topic settings:**
 +
 [console]
 ----
@@ -187,9 +256,9 @@ gadmin config apply
 gadmin restart gpe restpp
 ----
 +
-. Test TigerGraph CDC service
+. **Test the TigerGraph CDC Service**
 +
-Once the service is up and running, test it, by making an update to an existing graph, such as
+Once the TigerGraph CDC service is running, test it by making an update to an existing graph, such as:
 +
 * Run an xref:{page-component-version}@gsql-ref:querying:data-modification-statements.adoc#_update_statement[Update or Insert statement.]
 * Run a xref:API:built-in-endpoints.adoc#_loading_jobs[loading job].
@@ -199,17 +268,17 @@ Once the service is up and running, test it, by making an update to an existing 
 If an existing graph is not available, create a new graph by following TigerGraph’s link:https://github.com/tigergraph/ecosys/blob/master/demos/guru_scripts/docker/tutorial/4.x/README.md[GSQL V3 Tutorial] data.
 ====
 +
-. Lastly, check CDC messages.
+. **Check CDC Messages in the External Kafka Cluster.**
 +
-.To consume and display CDC messages, run:
+.**To consume and view CDC messages from the external Kafka cluster for CDC, run**:
 [console]
 ----
 MYIP=127.0.0.1
 
 KAFKA_ROOT=/home/tigergraph/test_cdc/download_kafka/kafka_2.13-3.3.1
-
 $KAFKA_ROOT/bin/kafka-console-consumer.sh --topic cdc_topic --from-beginning --bootstrap-server $MYIP:9092
 ----
+
 
 
 == Other Configuration Settings Table
@@ -241,21 +310,3 @@ When set to -1, there is an infinite timeout, which may slow the GPE shutdown.
 ¦ minutes: 30.
 
 |===
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/modules/system-management/pages/change-data-capture/cdc-state-monitoring.adoc
+++ b/modules/system-management/pages/change-data-capture/cdc-state-monitoring.adoc
@@ -1,13 +1,14 @@
 = CDC Monitoring and Reset
 
 == State Monitoring
-.Check the state of CDC Service with this command:
+
+Check the state of CDC Service with this command:
 [console]
 ----
 grun_p gpe "cat $(gadmin config get System.DataRoot)/gstore/0/part/cdc.yaml"
 ----
 
-.The response will look like this:
+The response should look like this:
 [console]
 ----
 ------------------ Output example for cdc.yaml on 1x2 cluster -------------------
@@ -24,8 +25,8 @@ If xref:tigergraph-server:system-management:change-data-capture/cdc-overview.ado
 
 If xref:tigergraph-server:system-management:change-data-capture/cdc-overview.adoc#_cdc_ha[CDC HA] is enabled (the default setting in multi-replica clusters), the CDC state file may reside on any node with GPE servers. For each partition, only the state file on the GPE leader is active; state files on other nodes may be missing or outdated. You can determine this by checking the tid in the file or the file's last update time.
 
-.For each CDC state field, see the table below:
-[cols="2", separator=¦ ]
+.Information Fields for CDC Status Report:
+[%autowidth, separator=¦ ]
 |===
 ¦ Field ¦ Meaning
 
@@ -50,13 +51,13 @@ All delta batches with tid `<safe_persistent_tid>` must have been written to ext
 
 DIM (Deleted Id Map) is an internal service designed to assist the CDC service in processing data updates that involve vertices already deleted from the database.
 
-.Check the state of DIM(Deleted Id Map) service with this command:
+.Command to check the state of DIM(Deleted Id Map) service
 [console]
 ----
 grun_p gpe "cat $(gadmin config get System.DataRoot)/gstore/0/part/deleted_idmap_state.yaml"
 ----
 
-.Check disk usage of DIM(Deleted Id Map) service with this command:
+.Command to check disk usage of DIM(Deleted Id Map) service
 [console]
 ----
 grun_p gpe "du -sh $(gadmin config get System.DataRoot)/gstore/0/part/deletedID_store"
@@ -64,7 +65,7 @@ grun_p gpe "du -sh $(gadmin config get System.DataRoot)/gstore/0/part/deletedID_
 
 The dim state file exists on all GPE nodes, unlike the cdc state file.
 
-.The response will look like this:
+.Example response for DIM state
 [console]
 ----
 ------------ Output example for deleted_idmap_state.yaml on 1x2 cluster ------------
@@ -85,8 +86,8 @@ purged_deletedvid_curr_tid: 3752091
 The purging task runs every 30 minutes by default.
 ====
 
-.For each DIM state field, see the table below:
-[cols="2", separator=¦ ]
+.Information fields for DIM state report
+[%autowidth, separator=¦ ]
 |===
 ¦ Field ¦ Meaning
 


### PR DESCRIPTION
Note that after all that work, this is mostly *presentation improvements*. 

It also includes the Kafka Security section that was adding in the original PR for this ticket (DOC-2334) on Jan. 14, merged into 3.10.
https://github.com/tigergraph/server-docs/commit/f995706e9502cd411f4c98c28cf28be756059113
Those changes should have been, but were not pushed to newer versions, which causes this whole mess.


