### PR TITLE
Update enabling-user-authentication.adoc for endpoint correction

### DIFF
--- a/modules/user-access/pages/enabling-user-authentication.adoc
+++ b/modules/user-access/pages/enabling-user-authentication.adoc
@@ -75,5 +75,5 @@ $ gadmin config apply
 $ gadmin restart restpp nginx gui gsql -y
 ----
 
-After enabling user authentication, the xref:API:gsql-endpoints.adoc#_create_new_jwt_token[`/requesttoken` endpoint] becomes available for you to generate tokens used to authenticate your REST requests to the REST++ server.
+After enabling user authentication, the xref:API:gsql-endpoints.adoc#_create_new_jwt_token[`/gsql/v1/tokens` endpoint] becomes available for you to generate tokens used to authenticate your REST requests to the REST++ server.
 


### PR DESCRIPTION
Changing to the correct token endpoint for 4.2