### PR TITLE
Clarify valid TigerGraph service names in documentation

### DIFF
--- a/modules/system-management/pages/management-commands.adoc
+++ b/modules/system-management/pages/management-commands.adoc
@@ -756,7 +756,7 @@ Usage:
   gadmin reset [service name...] [flags]
 
 Description:
-  Service name should be a valid TigerGraph service name, for example, GSE, RESTPP
+  Service name should be a valid TigerGraph service name, for example, GSE
   or GPE.
 
 Flags:


### PR DESCRIPTION
We do not support resetting RESTPP so I removed that from the doc.