### PR TITLE
Update S3 backup configuration description

### DIFF
--- a/modules/backup-and-restore/pages/configurations.adoc
+++ b/modules/backup-and-restore/pages/configurations.adoc
@@ -36,7 +36,7 @@ NOTE: For `System.Backup.Local.Enable`, `System.Backup.S3.Enable`, `System.Backu
 |System.Backup.Local.Path |Local path to store the backup files.
 Required if backup is to be stored locally. |null
 
-|System.Backup.S3.Enable |Enables or disables backup to AWS S3 or S3-compatible services such as Ceph S3.|`false`
+|System.Backup.S3.Enable |Enables or disables backup to AWS S3.|`false`
 
 |System.Backup.S3.AWSAccessKeyID |AWS Access Key ID for authentication (deprecated, use `System.Backup.S3.AccessKeyID` instead, which has a higher priority.) |`+nan+`
 


### PR DESCRIPTION
Removed mention of S3-compatible services from the backup configuration. We officially support AWS S3.