### PR TITLE
DOC-3163: Add Ubuntu 24.04 support and binutils requirement

### DIFF
--- a/modules/installation/pages/hw-and-sw-requirements.adoc
+++ b/modules/installation/pages/hw-and-sw-requirements.adoc
@@ -51,6 +51,9 @@ The software has been tested on the operating systems listed below:
 | Ubuntu 22.04 LTS
 | ✓
 
+| Ubuntu 24.04 LTS
+| ✓
+
 | Debian 10 & 11
 | ✓
 
@@ -108,6 +111,18 @@ sudo apt install tar curl cron iproute util-linux net-tools netcat coreutils ope
 # Ubuntu or Debian (Ver. 18.04):
 sudo apt install tar curl cron iproute2 util-linux net-tools netcat coreutils openssh-client openssh-server sshpass
 ----
+
+[NOTE]
+====
+For Ubuntu 24.04 and later, the `binutils` package is required.
+
+If it is not already installed, install it using:
+
+[source,console]
+----
+sudo apt install binutils
+----
+====
 
 [#_ntp]
 === NTP


### PR DESCRIPTION
Added support for Ubuntu 24.04 LTS and noted binutils requirement.